### PR TITLE
[codex] issue #2 browser load existing track/slot targeting

### DIFF
--- a/remote_script/AbletonCliRemote/command_backend_contract.py
+++ b/remote_script/AbletonCliRemote/command_backend_contract.py
@@ -159,6 +159,9 @@ class _BrowserBackend(Protocol):
         track: int,
         uri: str | None,
         path: str | None,
+        target_track_mode: str,
+        clip_slot: int | None,
+        preserve_track_name: bool,
     ) -> dict[str, Any]: ...
 
     def get_browser_tree(self, category_type: str) -> dict[str, Any]: ...

--- a/remote_script/AbletonCliRemote/command_backend_handlers_browser.py
+++ b/remote_script/AbletonCliRemote/command_backend_handlers_browser.py
@@ -16,6 +16,24 @@ from .command_backend_validators import (
 
 Handler = Callable[[CommandBackend, dict[str, Any]], dict[str, Any]]
 _ALLOWED_ITEM_TYPES = frozenset({"all", "folder", "device", "loadable"})
+_ALLOWED_TARGET_TRACK_MODES = frozenset({"auto", "existing", "new"})
+
+
+def _parse_target_track_mode(args: dict[str, Any]) -> str:
+    parsed = _non_empty_string("target_track_mode", args.get("target_track_mode", "auto")).lower()
+    if parsed not in _ALLOWED_TARGET_TRACK_MODES:
+        raise _invalid_argument(
+            message=f"target_track_mode must be one of auto/existing/new, got {parsed}",
+            hint="Use a supported target_track_mode.",
+        )
+    return parsed
+
+
+def _parse_optional_clip_slot(args: dict[str, Any]) -> int | None:
+    raw = args.get("clip_slot")
+    if raw is None:
+        return None
+    return _non_negative_int("clip_slot", raw)
 
 
 def _handle_load_instrument_or_effect(
@@ -29,7 +47,17 @@ def _handle_load_instrument_or_effect(
         second_key="path",
         required_hint="Provide --uri or --path.",
     )
-    return backend.load_instrument_or_effect(track, uri, path)
+    target_track_mode = _parse_target_track_mode(args)
+    clip_slot = _parse_optional_clip_slot(args)
+    preserve_track_name = _as_bool("preserve_track_name", args.get("preserve_track_name", False))
+    return backend.load_instrument_or_effect(
+        track,
+        uri,
+        path,
+        target_track_mode,
+        clip_slot,
+        preserve_track_name,
+    )
 
 
 def _handle_get_browser_tree(backend: CommandBackend, args: dict[str, Any]) -> dict[str, Any]:

--- a/remote_script/AbletonCliRemote/live_backend_parts/browser.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/browser.py
@@ -5,9 +5,10 @@ from time import perf_counter
 from typing import Any
 from urllib.parse import unquote
 
-from .base import _invalid_argument
+from .base import _invalid_argument, _not_supported_by_live_api
 
 _ALLOWED_ITEM_TYPES = frozenset({"all", "folder", "device", "loadable"})
+_ALLOWED_TARGET_TRACK_MODES = frozenset({"auto", "existing", "new"})
 
 
 class LiveBackendBrowserCatalogMixin:
@@ -251,11 +252,91 @@ class LiveBackendBrowserSearchIndexMixin:
 
 
 class LiveBackendBrowserReadMixin:
+    def _resolve_load_target_track(self, *, track: int, target_track_mode: str) -> tuple[Any, int]:
+        if target_track_mode not in _ALLOWED_TARGET_TRACK_MODES:
+            raise _invalid_argument(
+                message=(
+                    "target_track_mode must be one of auto/existing/new, "
+                    f"got {target_track_mode}"
+                ),
+                hint="Use a supported target_track_mode.",
+            )
+
+        if target_track_mode != "new":
+            return self._track_at(track), track
+
+        song = self._song()
+        tracks = list(getattr(song, "tracks", []))
+        if track > len(tracks):
+            raise _invalid_argument(
+                message=f"track out of range: {track}",
+                hint="Use a non-negative insertion index up to the current track count.",
+            )
+        create_midi_track = getattr(song, "create_midi_track", None)
+        if not callable(create_midi_track):
+            raise _not_supported_by_live_api(
+                message="Track creation API is not available in Live API",
+                hint="Use target_track_mode auto or existing instead.",
+            )
+        create_midi_track(track)
+        return self._track_at(track), track
+
+    def _select_track_for_load(self, *, song: Any, target_track: Any) -> None:
+        view = getattr(song, "view", None)
+        if view is None or not hasattr(view, "selected_track"):
+            raise _not_supported_by_live_api(
+                message="Song view selected_track API is not available in Live API",
+                hint="Use a Live version exposing song.view.selected_track.",
+            )
+        view.selected_track = target_track
+
+    def _select_clip_slot_for_load(
+        self,
+        *,
+        song: Any,
+        target_track: Any,
+        clip_slot: int | None,
+    ) -> int | None:
+        if clip_slot is None:
+            return None
+
+        slots = list(getattr(target_track, "clip_slots", []))
+        if clip_slot < 0 or clip_slot >= len(slots):
+            raise _invalid_argument(
+                message=f"clip_slot out of range: {clip_slot}",
+                hint="Use a valid clip slot index for the target track.",
+            )
+
+        view = getattr(song, "view", None)
+        if view is None:
+            raise _not_supported_by_live_api(
+                message="Song view is not available in Live API",
+                hint="Use --clip-slot only on versions exposing song.view.",
+            )
+
+        selected = False
+        scenes = list(getattr(song, "scenes", []))
+        if clip_slot < len(scenes) and hasattr(view, "selected_scene"):
+            view.selected_scene = scenes[clip_slot]
+            selected = True
+        if hasattr(view, "highlighted_clip_slot"):
+            view.highlighted_clip_slot = slots[clip_slot]
+            selected = True
+        if not selected:
+            raise _not_supported_by_live_api(
+                message="Clip slot selection API is not available in Live API",
+                hint="Use a Live version exposing selected_scene or highlighted_clip_slot.",
+            )
+        return clip_slot
+
     def load_instrument_or_effect(
         self,
         track: int,
         uri: str | None,
         path: str | None,
+        target_track_mode: str = "auto",
+        clip_slot: int | None = None,
+        preserve_track_name: bool = False,
     ) -> dict[str, Any]:
         if uri is None and path is None:
             raise _invalid_argument(
@@ -268,7 +349,6 @@ class LiveBackendBrowserReadMixin:
                 hint="Provide only one of uri or path.",
             )
 
-        target = self._track_at(track)
         if uri is not None:
             item = self._find_browser_item_by_uri(uri)
             if item is None:
@@ -290,16 +370,35 @@ class LiveBackendBrowserReadMixin:
             uri = serialized["uri"]
 
         song = self._song()
-        if hasattr(song, "view") and hasattr(song.view, "selected_track"):
-            song.view.selected_track = target
+        track_count_before = len(list(getattr(song, "tracks", [])))
+        target, resolved_track = self._resolve_load_target_track(
+            track=track,
+            target_track_mode=target_track_mode,
+        )
+        track_name_before = str(getattr(target, "name", "")) if preserve_track_name else None
+        self._select_track_for_load(song=song, target_track=target)
+        resolved_clip_slot = self._select_clip_slot_for_load(
+            song=song,
+            target_track=target,
+            clip_slot=clip_slot,
+        )
         self._browser().load_item(item)
+        if track_name_before is not None and hasattr(target, "name"):
+            target.name = track_name_before
+        track_count_after = len(list(getattr(song, "tracks", [])))
 
         return {
-            "track": track,
+            "track": resolved_track,
             "loaded": True,
             "item_name": str(getattr(item, "name", "")),
             "uri": uri,
             "path": serialized["path"],
+            "clip_slot": resolved_clip_slot,
+            "target_track_mode": target_track_mode,
+            "preserve_track_name": preserve_track_name,
+            "track_name": str(getattr(target, "name", "")),
+            "track_count": track_count_after,
+            "track_count_delta": track_count_after - track_count_before,
         }
 
     def get_browser_tree(self, category_type: str) -> dict[str, Any]:

--- a/src/ableton_cli/client/_client_browser_scenes.py
+++ b/src/ableton_cli/client/_client_browser_scenes.py
@@ -9,10 +9,18 @@ class _AbletonClientBrowserScenesMixin:
         track: int,
         uri: str | None = None,
         path: str | None = None,
+        target_track_mode: str = "auto",
+        clip_slot: int | None = None,
+        preserve_track_name: bool = False,
     ) -> dict[str, Any]:
-        args: dict[str, Any] = {"track": track}
+        args: dict[str, Any] = {
+            "track": track,
+            "target_track_mode": target_track_mode,
+            "preserve_track_name": preserve_track_name,
+        }
         self._add_if_not_none(args, "uri", uri)
         self._add_if_not_none(args, "path", path)
+        self._add_if_not_none(args, "clip_slot", clip_slot)
         return self._call("load_instrument_or_effect", args)
 
     def get_browser_tree(self, category_type: str = "all") -> dict[str, Any]:

--- a/src/ableton_cli/commands/browser.py
+++ b/src/ableton_cli/commands/browser.py
@@ -196,6 +196,21 @@ def browser_load(
     ctx: typer.Context,
     track: Annotated[int, typer.Argument(help="Track index (0-based)")],
     target: Annotated[str, typer.Argument(help="Browser target (URI or path)")],
+    target_track_mode: Annotated[
+        str,
+        typer.Option(
+            "--target-track-mode",
+            help="Track target mode: auto|existing|new",
+        ),
+    ] = "auto",
+    clip_slot: Annotated[
+        int | None,
+        typer.Option("--clip-slot", help="Clip slot (scene index, 0-based)"),
+    ] = None,
+    preserve_track_name: Annotated[
+        bool,
+        typer.Option("--preserve-track-name", help="Restore original track name after loading"),
+    ] = False,
 ) -> None:
     def _run() -> dict[str, object]:
         require_non_negative(
@@ -203,13 +218,48 @@ def browser_load(
             track,
             hint="Use a valid track index from 'ableton-cli tracks list'.",
         )
+        valid_mode = require_non_empty_string(
+            "target_track_mode",
+            target_track_mode,
+            hint="Use one of: auto, existing, new.",
+        ).lower()
+        if valid_mode not in {"auto", "existing", "new"}:
+            raise invalid_argument(
+                message=(
+                    "target_track_mode must be one of auto/existing/new, "
+                    f"got {target_track_mode}"
+                ),
+                hint="Use --target-track-mode auto, existing, or new.",
+            )
+        valid_clip_slot = (
+            require_non_negative(
+                "clip_slot",
+                clip_slot,
+                hint="Use a non-negative clip slot index.",
+            )
+            if clip_slot is not None
+            else None
+        )
         valid_uri, valid_path = _resolve_browser_target(target)
-        return get_client(ctx).load_instrument_or_effect(track, uri=valid_uri, path=valid_path)
+        return get_client(ctx).load_instrument_or_effect(
+            track,
+            uri=valid_uri,
+            path=valid_path,
+            target_track_mode=valid_mode,
+            clip_slot=valid_clip_slot,
+            preserve_track_name=preserve_track_name,
+        )
 
     execute_command(
         ctx,
         command="browser load",
-        args={"track": track, "target": target},
+        args={
+            "track": track,
+            "target": target,
+            "target_track_mode": target_track_mode,
+            "clip_slot": clip_slot,
+            "preserve_track_name": preserve_track_name,
+        },
         action=_run,
     )
 

--- a/tests/test_ableton_client.py
+++ b/tests/test_ableton_client.py
@@ -275,6 +275,24 @@ def test_client_sends_request_timeout_meta(monkeypatch) -> None:
                 "case_sensitive": True,
             },
         ),
+        (
+            lambda client: client.load_instrument_or_effect(
+                track=2,
+                uri=None,
+                path="sounds/Bass Loop.alc",
+                target_track_mode="existing",
+                clip_slot=4,
+                preserve_track_name=True,
+            ),
+            "load_instrument_or_effect",
+            {
+                "track": 2,
+                "path": "sounds/Bass Loop.alc",
+                "target_track_mode": "existing",
+                "clip_slot": 4,
+                "preserve_track_name": True,
+            },
+        ),
     ],
 )
 def test_client_builds_optional_arguments_deterministically(

--- a/tests/test_cli_new_commands.py
+++ b/tests/test_cli_new_commands.py
@@ -150,8 +150,24 @@ class _ClientStub:
     def get_browser_item(self, uri: str | None, path: str | None):  # noqa: ANN201
         return {"uri": uri, "path": path, "found": True}
 
-    def load_instrument_or_effect(self, track: int, uri: str | None, path: str | None):  # noqa: ANN201
-        return {"track": track, "uri": uri, "path": path, "loaded": True}
+    def load_instrument_or_effect(  # noqa: ANN201
+        self,
+        track: int,
+        uri: str | None,
+        path: str | None,
+        target_track_mode: str = "auto",
+        clip_slot: int | None = None,
+        preserve_track_name: bool = False,
+    ):
+        return {
+            "track": track,
+            "uri": uri,
+            "path": path,
+            "target_track_mode": target_track_mode,
+            "clip_slot": clip_slot,
+            "preserve_track_name": preserve_track_name,
+            "loaded": True,
+        }
 
     def load_drum_kit(  # noqa: ANN201
         self,
@@ -802,6 +818,41 @@ def test_browser_load_supports_uri_and_path_target(runner, cli_app, monkeypatch)
     assert uri_payload["result"]["path"] is None
     assert path_payload["result"]["path"] == "instruments/Operator"
     assert path_payload["result"]["uri"] is None
+
+
+def test_browser_load_supports_target_track_mode_clip_slot_and_preserve_track_name(
+    runner,
+    cli_app,
+    monkeypatch,
+) -> None:
+    from ableton_cli.commands import browser
+
+    monkeypatch.setattr(browser, "get_client", lambda ctx: _ClientStub())
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "1",
+            "sounds/Bass Loop.alc",
+            "--target-track-mode",
+            "existing",
+            "--clip-slot",
+            "3",
+            "--preserve-track-name",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["result"]["track"] == 1
+    assert payload["result"]["target_track_mode"] == "existing"
+    assert payload["result"]["clip_slot"] == 3
+    assert payload["result"]["preserve_track_name"] is True
 
 
 def test_browser_load_drum_kit_supports_kit_uri_or_path(runner, cli_app, monkeypatch) -> None:

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -244,6 +244,46 @@ def test_browser_load_rejects_non_uri_non_path_target(runner, cli_app) -> None:
     assert payload["error"]["code"] == "INVALID_ARGUMENT"
 
 
+def test_browser_load_rejects_invalid_target_track_mode(runner, cli_app) -> None:
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "0",
+            "instruments/Operator",
+            "--target-track-mode",
+            "legacy",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "INVALID_ARGUMENT"
+
+
+def test_browser_load_rejects_negative_clip_slot(runner, cli_app) -> None:
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "0",
+            "instruments/Operator",
+            "--clip-slot",
+            "-1",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "INVALID_ARGUMENT"
+
+
 def test_browser_load_drum_kit_requires_exactly_one_kit_selector(runner, cli_app) -> None:
     none_selected = runner.invoke(
         cli_app,

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -192,7 +192,18 @@ class _Browser:
                 _BrowserItem(name="Synth", uri="inst:synth", is_device=True, is_loadable=True),
             ],
         )
-        self.sounds = _BrowserItem(name="Sounds", uri="cat:sounds", children=[])
+        self.sounds = _BrowserItem(
+            name="Sounds",
+            uri="cat:sounds",
+            children=[
+                _BrowserItem(
+                    name="Bass Loop.alc",
+                    uri="clip:bass-loop-alc",
+                    is_device=False,
+                    is_loadable=True,
+                )
+            ],
+        )
         self.drums = _BrowserItem(
             name="Drums",
             uri="cat:drums",
@@ -221,6 +232,25 @@ class _Browser:
         self.midi_effects = _BrowserItem(name="MIDI Effects", uri="cat:midi", children=[])
 
     def load_item(self, item: _BrowserItem) -> None:
+        uri = str(getattr(item, "uri", ""))
+        if uri.startswith("clip:"):
+            selected_scene = self._song.view.selected_scene
+            if selected_scene is None:
+                self._song.tracks.append(
+                    _Track(name=str(item.name), has_audio_input=False, has_midi_input=True)
+                )
+                return
+
+            target_track = self._song.view.selected_track
+            scene_index = list(self._song.scenes).index(selected_scene)
+            while scene_index >= len(target_track.clip_slots):
+                target_track.clip_slots.append(_ClipSlot())
+            slot = target_track.clip_slots[scene_index]
+            if not slot.has_clip:
+                slot.create_clip(length=1.0)
+            target_track.name = str(item.name)
+            return
+
         target = self._song.view.selected_track
         target.devices.append(
             _Device(
@@ -234,6 +264,8 @@ class _Browser:
 @dataclass(slots=True)
 class _SongView:
     selected_track: _Track
+    selected_scene: _Scene | None = None
+    highlighted_clip_slot: _ClipSlot | None = None
 
 
 class _Song:
@@ -256,7 +288,7 @@ class _Song:
             clip_slots=[],
             devices=[],
         )
-        self.view = _SongView(selected_track=self.tracks[0])
+        self.view = _SongView(selected_track=self.tracks[0], selected_scene=self.scenes[0])
         self.stop_all_clips_calls = 0
 
     def start_playing(self) -> None:
@@ -685,6 +717,46 @@ def test_live_backend_load_with_path_and_non_loadable_path_rejected() -> None:
     with pytest.raises(CommandError) as exc_info:
         backend.load_instrument_or_effect(0, uri=None, path="drums/Kits")
     assert "not loadable" in exc_info.value.message
+
+
+def test_live_backend_load_existing_mode_targets_clip_slot_and_preserves_track_name() -> None:
+    surface = _SurfaceStub()
+    backend = LiveBackend(surface)
+
+    loaded = backend.load_instrument_or_effect(
+        0,
+        uri=None,
+        path="sounds/Bass Loop.alc",
+        target_track_mode="existing",
+        clip_slot=1,
+        preserve_track_name=True,
+    )
+
+    target_track = surface.song().tracks[0]
+    assert loaded["loaded"] is True
+    assert loaded["track"] == 0
+    assert loaded["clip_slot"] == 1
+    assert loaded["target_track_mode"] == "existing"
+    assert loaded["track_name"] == "Track 1"
+    assert loaded["track_count"] == 2
+    assert target_track.name == "Track 1"
+    assert target_track.clip_slots[1].has_clip is True
+
+
+def test_live_backend_load_existing_mode_rejects_invalid_clip_slot() -> None:
+    backend = LiveBackend(_SurfaceStub())
+
+    with pytest.raises(CommandError) as exc_info:
+        backend.load_instrument_or_effect(
+            0,
+            uri=None,
+            path="sounds/Bass Loop.alc",
+            target_track_mode="existing",
+            clip_slot=99,
+            preserve_track_name=False,
+        )
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
 
 
 def test_live_backend_device_parameter_set() -> None:

--- a/tests/test_remote_command_backend.py
+++ b/tests/test_remote_command_backend.py
@@ -141,8 +141,24 @@ class _BackendStub:
     def clip_duplicate(self, track: int, src_clip: int, dst_clip: int):  # noqa: ANN201
         return {"track": track, "src_clip": src_clip, "dst_clip": dst_clip, "duplicated": True}
 
-    def load_instrument_or_effect(self, track: int, uri: str | None, path: str | None):  # noqa: ANN201
-        return {"track": track, "uri": uri, "path": path, "loaded": True}
+    def load_instrument_or_effect(  # noqa: ANN201
+        self,
+        track: int,
+        uri: str | None,
+        path: str | None,
+        target_track_mode: str,
+        clip_slot: int | None,
+        preserve_track_name: bool,
+    ):
+        return {
+            "track": track,
+            "uri": uri,
+            "path": path,
+            "target_track_mode": target_track_mode,
+            "clip_slot": clip_slot,
+            "preserve_track_name": preserve_track_name,
+            "loaded": True,
+        }
 
     def get_browser_tree(self, category_type: str):  # noqa: ANN201
         return {"category_type": category_type}
@@ -690,7 +706,39 @@ def test_dispatch_calls_backend_for_browser_load_with_path() -> None:
         "load_instrument_or_effect",
         {"track": 2, "path": "instruments/Drift"},
     )
-    assert result == {"track": 2, "uri": None, "path": "instruments/Drift", "loaded": True}
+    assert result == {
+        "track": 2,
+        "uri": None,
+        "path": "instruments/Drift",
+        "target_track_mode": "auto",
+        "clip_slot": None,
+        "preserve_track_name": False,
+        "loaded": True,
+    }
+
+
+def test_dispatch_calls_backend_for_browser_load_with_existing_mode_and_clip_slot() -> None:
+    backend = _BackendStub()
+    result = dispatch_command(
+        backend,
+        "load_instrument_or_effect",
+        {
+            "track": 1,
+            "path": "sounds/Bass Loop.alc",
+            "target_track_mode": "existing",
+            "clip_slot": 3,
+            "preserve_track_name": True,
+        },
+    )
+    assert result == {
+        "track": 1,
+        "uri": None,
+        "path": "sounds/Bass Loop.alc",
+        "target_track_mode": "existing",
+        "clip_slot": 3,
+        "preserve_track_name": True,
+        "loaded": True,
+    }
 
 
 def test_dispatch_calls_backend_for_add_notes_to_clip() -> None:
@@ -1042,6 +1090,38 @@ def test_dispatch_rejects_browser_load_with_uri_and_path() -> None:
             backend,
             "load_instrument_or_effect",
             {"track": 0, "uri": "query:Synths#Drift", "path": "instruments/Drift"},
+        )
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
+
+
+def test_dispatch_rejects_browser_load_with_invalid_target_track_mode() -> None:
+    backend = _BackendStub()
+    with pytest.raises(CommandError) as exc_info:
+        dispatch_command(
+            backend,
+            "load_instrument_or_effect",
+            {
+                "track": 0,
+                "path": "instruments/Drift",
+                "target_track_mode": "legacy",
+            },
+        )
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
+
+
+def test_dispatch_rejects_browser_load_with_negative_clip_slot() -> None:
+    backend = _BackendStub()
+    with pytest.raises(CommandError) as exc_info:
+        dispatch_command(
+            backend,
+            "load_instrument_or_effect",
+            {
+                "track": 0,
+                "path": "instruments/Drift",
+                "clip_slot": -1,
+            },
         )
 
     assert exc_info.value.code == "INVALID_ARGUMENT"


### PR DESCRIPTION
## Summary
This PR resolves issue #2 by making `browser load` deterministic for clip-oriented assets (such as `.alc`) when users need to target an existing track and clip slot.

## User impact
Before this change, `browser load` could create a new track when loading clip content, even when the user specified an existing track. That made non-interactive arrangement scripts unreliable.

With this PR, users can explicitly control targeting behavior from CLI:
- `--target-track-mode auto|existing|new`
- `--clip-slot <index>`
- `--preserve-track-name`

The command now returns machine-readable placement details (`track`, `clip_slot`, mode metadata), so automation can branch deterministically.

## Root cause
`browser load` previously passed only track + target item and relied on default Live selection state. It did not set clip-slot selection context, and did not expose mode controls to the CLI/client/remote handler/backend path.

## Fix
- Extended `browser load` CLI to accept and validate:
  - `--target-track-mode auto|existing|new`
  - `--clip-slot`
  - `--preserve-track-name`
- Propagated new args through client and remote command handler.
- Updated backend browser loader to:
  - validate target mode
  - optionally create a new track when `target_track_mode=new`
  - explicitly select target track and clip slot context
  - optionally restore track name (`--preserve-track-name`)
  - return placement metadata including `track`, `clip_slot`, `track_count`, `track_count_delta`
- Added/updated tests across CLI, client, command dispatch, and live backend behavior.

## Validation
- `uv run pytest -q`
- 218 passed

Closes #2
