### PR TITLE
[codex] fix CI ruff format drift in browser load changes

### DIFF
--- a/remote_script/AbletonCliRemote/live_backend_parts/browser.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/browser.py
@@ -256,8 +256,7 @@ class LiveBackendBrowserReadMixin:
         if target_track_mode not in _ALLOWED_TARGET_TRACK_MODES:
             raise _invalid_argument(
                 message=(
-                    "target_track_mode must be one of auto/existing/new, "
-                    f"got {target_track_mode}"
+                    f"target_track_mode must be one of auto/existing/new, got {target_track_mode}"
                 ),
                 hint="Use a supported target_track_mode.",
             )

--- a/src/ableton_cli/commands/browser.py
+++ b/src/ableton_cli/commands/browser.py
@@ -226,8 +226,7 @@ def browser_load(
         if valid_mode not in {"auto", "existing", "new"}:
             raise invalid_argument(
                 message=(
-                    "target_track_mode must be one of auto/existing/new, "
-                    f"got {target_track_mode}"
+                    f"target_track_mode must be one of auto/existing/new, got {target_track_mode}"
                 ),
                 hint="Use --target-track-mode auto, existing, or new.",
             )


### PR DESCRIPTION
## Summary
This PR fixes CI failures introduced by formatting drift in the issue #2 changes.

## Failure context
GitHub Actions runs failed at `Ruff format check` on both macOS and Windows:
- `src/ableton_cli/commands/browser.py`
- `remote_script/AbletonCliRemote/live_backend_parts/browser.py`

The failures were caused by formatting mismatches only; functional tests were not failing.

## Fix
Applied `ruff format` to the two files above so they match repository formatting rules.

## Validation
- `uv run ruff format --check .`
- `uv run pytest -q`
