### PR TITLE
[codex] テスト実行時にruffチェックを必ず通す共通導線を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,8 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
 
-      - name: Ruff check
-        run: uv run ruff check .
-
-      - name: Ruff format check
-        run: uv run ruff format --check .
-
-      - name: Run tests
-        run: uv run pytest
+      - name: Run lint and tests
+        run: uv run python -m ableton_cli.dev_checks
 
       - name: CLI help
         run: uv run ableton-cli --help

--- a/README.md
+++ b/README.md
@@ -315,9 +315,7 @@ Detailed specification and known limits:
 
 ```bash
 uv sync
-uv run ruff check .
-uv run ruff format --check .
-uv run pytest
+uv run python -m ableton_cli.dev_checks
 uv run ableton-cli --help
 uv run ableton-cli --version
 ```

--- a/src/ableton_cli/dev_checks.py
+++ b/src/ableton_cli/dev_checks.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+
+DEFAULT_CHECK_COMMANDS: tuple[tuple[str, ...], ...] = (
+    ("uv", "run", "ruff", "check", "."),
+    ("uv", "run", "ruff", "format", "--check", "."),
+    ("uv", "run", "pytest"),
+)
+
+
+def _run_command(command: Sequence[str]) -> int:
+    print(f"$ {' '.join(command)}", flush=True)
+    completed = subprocess.run(tuple(command), check=False)
+    return int(completed.returncode)
+
+
+def run_default_checks(
+    *,
+    commands: Sequence[Sequence[str]] = DEFAULT_CHECK_COMMANDS,
+) -> int:
+    for command in commands:
+        exit_code = _run_command(command)
+        if exit_code != 0:
+            return exit_code
+    return 0
+
+
+def main() -> int:
+    return run_default_checks()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dev_checks.py
+++ b/tests/test_dev_checks.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ableton_cli import dev_checks
+
+
+def test_run_default_checks_runs_commands_in_order(monkeypatch) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    def _run(command: tuple[str, ...], check: bool) -> SimpleNamespace:  # noqa: ANN202
+        assert check is False
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(dev_checks.subprocess, "run", _run)
+
+    result = dev_checks.run_default_checks()
+
+    assert result == 0
+    assert commands == list(dev_checks.DEFAULT_CHECK_COMMANDS)
+
+
+def test_run_default_checks_stops_on_first_failure(monkeypatch) -> None:
+    commands: list[tuple[str, ...]] = []
+    exits = [0, 1, 0]
+
+    def _run(command: tuple[str, ...], check: bool) -> SimpleNamespace:  # noqa: ANN202
+        assert check is False
+        commands.append(command)
+        return SimpleNamespace(returncode=exits[len(commands) - 1])
+
+    monkeypatch.setattr(dev_checks.subprocess, "run", _run)
+
+    result = dev_checks.run_default_checks()
+
+    assert result == 1
+    assert commands == list(dev_checks.DEFAULT_CHECK_COMMANDS[:2])


### PR DESCRIPTION
## 目的
今回のような「テストは通るが `ruff format --check` でCIが落ちる」再発を防ぐため、
開発時とCIのチェック手順を1つに統一します。

## 変更内容
- 共通チェック実行モジュールを追加
  - `python -m ableton_cli.dev_checks`
  - 実行順: `ruff check` → `ruff format --check` → `pytest`
  - 途中で失敗したらその場で終了
- CIを共通コマンド経由に変更
  - `.github/workflows/ci.yml`
- 開発手順のコマンドを更新
  - `README.md`
- 共通チェックの挙動テストを追加
  - `tests/test_dev_checks.py`

## ユーザー影響
- 開発者は `uv run python -m ableton_cli.dev_checks` を実行すれば、
  CIと同じ順序・同じ条件で事前確認できます。
- フォーマット漏れがPR前に見つかるため、CI失敗の手戻りが減ります。

## 確認したこと
- `uv run python -m ableton_cli.dev_checks`
- `uv run pytest tests/test_dev_checks.py -q`
