### PR TITLE
[codex] fix transport play/stop is_playing consistency

### DIFF
--- a/remote_script/AbletonCliRemote/live_backend_parts/song_transport.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/song_transport.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from ..command_backend import MAX_BPM, MAX_PANNING, MAX_VOLUME, MIN_BPM, MIN_PANNING, MIN_VOLUME
 from .base import _invalid_argument, _not_supported_by_live_api
+
+_TRANSPORT_STATE_TIMEOUT_SECONDS = 0.25
+_TRANSPORT_STATE_POLL_INTERVAL_SECONDS = 0.01
 
 
 class LiveBackendSongSessionMixin:
@@ -179,6 +183,16 @@ class LiveBackendSongSessionMixin:
 
 
 class LiveBackendTransportMixerMixin:
+    def _wait_for_transport_state(self, *, expected: bool | None = None) -> bool:
+        deadline = time.monotonic() + _TRANSPORT_STATE_TIMEOUT_SECONDS
+        while True:
+            is_playing = bool(self._song().is_playing)
+            if expected is None or is_playing is expected:
+                return is_playing
+            if time.monotonic() >= deadline:
+                return is_playing
+            time.sleep(_TRANSPORT_STATE_POLL_INTERVAL_SECONDS)
+
     def transport_play(self) -> dict[str, Any]:
         return self.start_playback()
 
@@ -187,21 +201,23 @@ class LiveBackendTransportMixerMixin:
 
     def transport_toggle(self) -> dict[str, Any]:
         song = self._song()
-        if song.is_playing:
+        if self._wait_for_transport_state():
             song.stop_playing()
+            expected = False
         else:
             song.start_playing()
-        return {"is_playing": bool(song.is_playing)}
+            expected = True
+        return {"is_playing": self._wait_for_transport_state(expected=expected)}
 
     def start_playback(self) -> dict[str, Any]:
         song = self._song()
         song.start_playing()
-        return {"is_playing": bool(song.is_playing)}
+        return {"is_playing": self._wait_for_transport_state(expected=True)}
 
     def stop_playback(self) -> dict[str, Any]:
         song = self._song()
         song.stop_playing()
-        return {"is_playing": bool(song.is_playing)}
+        return {"is_playing": self._wait_for_transport_state(expected=False)}
 
     def transport_tempo_get(self) -> dict[str, Any]:
         return {"tempo": float(self._song().tempo)}

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -326,6 +326,37 @@ class _Song:
         self.scenes.insert(to_index, scene)
 
 
+class _EventuallyConsistentSong(_Song):
+    def __init__(self) -> None:
+        self._actual_is_playing = False
+        self._reported_is_playing = False
+        self._stale_reads_remaining = 0
+        super().__init__()
+
+    @property
+    def is_playing(self) -> bool:
+        if self._stale_reads_remaining > 0:
+            self._stale_reads_remaining -= 1
+            return bool(self._reported_is_playing)
+        self._reported_is_playing = bool(self._actual_is_playing)
+        return bool(self._actual_is_playing)
+
+    @is_playing.setter
+    def is_playing(self, value: bool) -> None:
+        state = bool(value)
+        self._actual_is_playing = state
+        self._reported_is_playing = state
+        self._stale_reads_remaining = 0
+
+    def start_playing(self) -> None:
+        self._actual_is_playing = True
+        self._stale_reads_remaining = 1
+
+    def stop_playing(self) -> None:
+        self._actual_is_playing = False
+        self._stale_reads_remaining = 1
+
+
 @dataclass(slots=True)
 class _Scene:
     name: str
@@ -350,6 +381,12 @@ class _SurfaceStub:
 
     def application(self) -> _Application:
         return self._app
+
+
+class _EventuallyConsistentSurfaceStub(_SurfaceStub):
+    def __init__(self) -> None:
+        self._song_obj = _EventuallyConsistentSong()
+        self._app = _Application(self._song_obj)
 
 
 def _note() -> dict[str, Any]:
@@ -497,6 +534,13 @@ def test_live_backend_transport_and_tempo() -> None:
     assert backend.transport_tempo_set(128.0)["tempo"] == 128.0
     assert backend.transport_tempo_get()["tempo"] == 128.0
     assert backend.stop_playback()["is_playing"] is False
+
+
+def test_live_backend_transport_waits_for_committed_state() -> None:
+    backend = LiveBackend(_EventuallyConsistentSurfaceStub())
+
+    assert backend.transport_play()["is_playing"] is True
+    assert backend.transport_stop()["is_playing"] is False
 
 
 def test_live_backend_track_volume_set() -> None:


### PR DESCRIPTION
## 概要
`transport play` / `transport stop` の直後に返す `is_playing` が、実際の再生状態より1拍遅れで古い値になる問題を修正しました。

Closes #6

## ユーザー影響
自動実行フローで `transport` コマンドの戻り値をそのまま分岐条件に使うと、再生中なのに `false`、停止中なのに `true` になることがあり、後続処理（scene fire / stop / batch）の判定が崩れる状態でした。

## 原因
Live API 側の状態反映が即時ではないケースで、コマンド実行直後に `song.is_playing` を1回だけ読んで返していたため、確定前の状態を返すことがありました。

## 修正内容
- `LiveBackendTransportMixerMixin` に、`song.is_playing` が期待値に揃うまで短時間ポーリングする内部同期処理を追加
- `start_playback` / `stop_playback` / `transport_toggle` からこの同期処理を使うように変更
- 「最初の1回だけ古い状態を返す Song」を再現するテストスタブを追加し、`transport_play` / `transport_stop` が確定状態を返すことを検証

## テスト
- `uv run pytest tests/test_live_backend.py -k 'transport_and_tempo or transport_waits_for_committed_state' -q`
- `uv run pytest tests/test_live_backend.py -q`
- `uv run pytest tests/test_remote_command_backend.py -q`
