### PR TITLE
[codex] fix CI ruff B009 in clip active handlers

### DIFF
--- a/remote_script/AbletonCliRemote/live_backend_parts/tracks_clips.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/tracks_clips.py
@@ -242,7 +242,7 @@ class LiveBackendTracksClipsMixin:
         return {
             "track": track,
             "clip": clip,
-            "active": not bool(getattr(clip_obj, "muted")),
+            "active": not bool(clip_obj.muted),
         }
 
     def clip_active_set(self, track: int, clip: int, value: bool) -> dict[str, Any]:
@@ -263,7 +263,7 @@ class LiveBackendTracksClipsMixin:
         return {
             "track": track,
             "clip": clip,
-            "active": not bool(getattr(clip_obj, "muted")),
+            "active": not bool(clip_obj.muted),
         }
 
     def clip_duplicate(self, track: int, src_clip: int, dst_clip: int) -> dict[str, Any]:


### PR DESCRIPTION
## 概要
`clip active get/set` 実装で導入された `ruff B009` を修正し、CI の lint 失敗を解消します。

## 問題
GitHub Actions の `Run lint and tests` で以下が検出され失敗していました。
- `remote_script/AbletonCliRemote/live_backend_parts/tracks_clips.py:245`
- `remote_script/AbletonCliRemote/live_backend_parts/tracks_clips.py:266`

`getattr(clip_obj, "muted")` のように定数属性へ `getattr` を使っており、`B009` に違反。

## 修正
- 上記2箇所を `clip_obj.muted` の直接属性アクセスへ変更

## 検証
- `uv run ruff check .`
- `uv run pytest -q`
