### PR TITLE
[codex] document merge gate to prevent CI regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,22 @@ uv run ableton-cli --help
 uv run ableton-cli --version
 ```
 
+## Merge Gate
+
+Before merge, wait until all required checks are green on the PR head commit:
+
+```bash
+gh pr checks --watch
+```
+
+`main` is protected with required status checks:
+
+- `test (macos-latest)`
+- `test (windows-latest)`
+- `quality-harness`
+
+Do not merge while any required check is pending or failing.
+
 ## Troubleshooting
 
 1. Run `uv run ableton-cli doctor`.


### PR DESCRIPTION
## 概要
CI 再発防止の運用ルールを README に明文化しました。

## 変更内容
- `README.md` に `Merge Gate` セクションを追加
- マージ前に `gh pr checks --watch` で必須チェック完了を待つ手順を記載
- `main` の required checks 名を明記
  - `test (macos-latest)`
  - `test (windows-latest)`
  - `quality-harness`

## 補足
合わせて `main` ブランチに required status checks を設定済みです（API で適用・確認）。
