### PR TITLE
[codex] pingでLive API実効可否を事前判定できるようにする

### DIFF
--- a/remote_script/AbletonCliRemote/live_backend_parts/base.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/base.py
@@ -33,6 +33,38 @@ def _not_supported_by_live_api(message: str, hint: str) -> CommandError:
 class LiveBackendBaseMixin:
     _control_surface: Any
 
+    @staticmethod
+    def _is_callable_attribute(target: Any, name: str) -> bool:
+        return bool(callable(getattr(target, name, None)))
+
+    def _live_api_support(self) -> dict[str, bool]:
+        app = self._control_surface.application()
+        song = self._control_surface.song()
+
+        song_new_supported = self._is_callable_attribute(app, "new_live_set")
+        song_save_supported = self._is_callable_attribute(app, "save_live_set")
+        song_export_audio_supported = self._is_callable_attribute(app, "export_audio")
+        has_record_mode = hasattr(song, "record_mode")
+        arrangement_record_start_supported = has_record_mode or self._is_callable_attribute(
+            song,
+            "start_arrangement_recording",
+        )
+        arrangement_record_stop_supported = has_record_mode or self._is_callable_attribute(
+            song,
+            "stop_arrangement_recording",
+        )
+
+        return {
+            "song_new_supported": song_new_supported,
+            "song_save_supported": song_save_supported,
+            "song_export_audio_supported": song_export_audio_supported,
+            "arrangement_record_start_supported": arrangement_record_start_supported,
+            "arrangement_record_stop_supported": arrangement_record_stop_supported,
+            "arrangement_record_supported": (
+                arrangement_record_start_supported and arrangement_record_stop_supported
+            ),
+        }
+
     def _song(self) -> Any:
         return self._control_surface.song()
 
@@ -294,6 +326,7 @@ class LiveBackendBaseMixin:
         return {
             "protocol_version": PROTOCOL_VERSION,
             "remote_script_version": REMOTE_SCRIPT_VERSION,
+            "api_support": self._live_api_support(),
         }
 
     def _get_device_type(self, device: Any) -> str:

--- a/src/ableton_cli/commands/setup.py
+++ b/src/ableton_cli/commands/setup.py
@@ -191,6 +191,7 @@ def register(app: typer.Typer) -> None:
                 "remote_script_version": result.get("remote_script_version"),
                 "supported_commands": result.get("supported_commands"),
                 "command_set_hash": result.get("command_set_hash"),
+                "api_support": result.get("api_support"),
                 "rtt_ms": round(rtt_ms, 3),
             }
 

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -98,6 +98,11 @@ def test_ping_includes_capabilities_when_remote_reports_them(runner, cli_app, mo
                 "remote_script_version": "0.2.0",
                 "supported_commands": ["ping", "song_info"],
                 "command_set_hash": "abc123",
+                "api_support": {
+                    "song_save_supported": False,
+                    "song_export_audio_supported": False,
+                    "arrangement_record_supported": False,
+                },
             }
 
     monkeypatch.setattr(setup, "get_client", lambda ctx: _ClientStub())
@@ -112,6 +117,9 @@ def test_ping_includes_capabilities_when_remote_reports_them(runner, cli_app, mo
     assert payload["ok"] is True
     assert payload["result"]["supported_commands"] == ["ping", "song_info"]
     assert payload["result"]["command_set_hash"] == "abc123"
+    assert payload["result"]["api_support"]["song_save_supported"] is False
+    assert payload["result"]["api_support"]["song_export_audio_supported"] is False
+    assert payload["result"]["api_support"]["arrangement_record_supported"] is False
 
 
 def test_config_set_updates_key_and_returns_json_envelope(runner, cli_app, tmp_path) -> None:

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -528,6 +528,45 @@ def _set_track_device_to_effect(
     target_track.devices[device] = effect_device
 
 
+def test_live_backend_ping_info_reports_api_support_matrix() -> None:
+    backend = LiveBackend(_SurfaceStub())
+
+    result = backend.ping_info()
+
+    assert result["protocol_version"] == 2
+    assert "remote_script_version" in result
+    assert result["api_support"] == {
+        "song_new_supported": False,
+        "song_save_supported": False,
+        "song_export_audio_supported": False,
+        "arrangement_record_start_supported": False,
+        "arrangement_record_stop_supported": False,
+        "arrangement_record_supported": False,
+    }
+
+
+def test_live_backend_ping_info_reports_api_support_true_when_available() -> None:
+    surface = _SurfaceStub()
+    app = surface.application()
+    song = surface.song()
+    app.new_live_set = lambda: None
+    app.save_live_set = lambda _path: None
+    app.export_audio = lambda _path: None
+    song.record_mode = False
+    backend = LiveBackend(surface)
+
+    result = backend.ping_info()
+
+    assert result["api_support"] == {
+        "song_new_supported": True,
+        "song_save_supported": True,
+        "song_export_audio_supported": True,
+        "arrangement_record_start_supported": True,
+        "arrangement_record_stop_supported": True,
+        "arrangement_record_supported": True,
+    }
+
+
 def test_live_backend_transport_and_tempo() -> None:
     backend = LiveBackend(_SurfaceStub())
 

--- a/tests/test_remote_command_backend.py
+++ b/tests/test_remote_command_backend.py
@@ -8,7 +8,17 @@ from remote_script.AbletonCliRemote.command_backend import CommandError, dispatc
 
 class _BackendStub:
     def ping_info(self):  # noqa: ANN201
-        return {"pong": True}
+        return {
+            "pong": True,
+            "api_support": {
+                "song_new_supported": True,
+                "song_save_supported": True,
+                "song_export_audio_supported": True,
+                "arrangement_record_start_supported": True,
+                "arrangement_record_stop_supported": True,
+                "arrangement_record_supported": True,
+            },
+        }
 
     def get_session_info(self):  # noqa: ANN201
         return {"tempo": 120.0}
@@ -512,6 +522,9 @@ def test_dispatch_ping_includes_supported_commands_and_hash() -> None:
     result = dispatch_command(backend, "ping", {})
 
     assert result["pong"] is True
+    assert result["api_support"]["song_save_supported"] is True
+    assert result["api_support"]["song_export_audio_supported"] is True
+    assert result["api_support"]["arrangement_record_supported"] is True
     assert "supported_commands" in result
     assert "command_set_hash" in result
     assert isinstance(result["supported_commands"], list)


### PR DESCRIPTION
## 概要
`ping` のJSON結果に `api_support` セクションを追加し、`song save/export` や `arrangement record` の実行可否を、実行前に機械可読で判定できるようにしました。

Closes #7

## 変更前の問題
一部のLive APIは環境差分（LiveバージョンやAPI公開状況）で未対応なことがあり、`song save` / `song export audio` / `arrangement record` を実行して初めて `not_supported_by_live_api` で失敗していました。
このため、バッチ実行前の分岐設計が難しい状態でした。

## 根本原因
`ping` が返すのはプロトコル互換性（`supported_commands`）までで、実行環境ごとのLive API実効可否（呼べるメソッドが実在するか）の情報を返していませんでした。

## 今回の修正
Remote Scriptの `ping_info` に `api_support` を追加し、以下のブール値を返すようにしました。

- `song_new_supported`
- `song_save_supported`
- `song_export_audio_supported`
- `arrangement_record_start_supported`
- `arrangement_record_stop_supported`
- `arrangement_record_supported`（start/stop両方が可能なとき true）

あわせてCLI側の `ableton-cli ping` でも `result.api_support` をそのまま出力するようにしています。

## 利用者への影響
`--output json ping` の結果だけで、保存/書き出し/アレンジ録音開始停止を事前分岐できます。
`not_supported_by_live_api` を実行時に初めて知るケースを減らせます。

## テスト
以下を追加・更新しています。

- LiveBackendの `ping_info` が `api_support` を返すこと
- Live APIが存在する場合に `api_support` が true になること
- Remote command dispatchの `ping` 結果に `api_support` が含まれること
- CLI `ping` のJSON結果に `api_support` が含まれること

ローカル確認:
- `uv run pytest`（226 passed）
