### PR TITLE
[codex] fix browser load uri targets containing slashes

### DIFF
--- a/src/ableton_cli/commands/browser.py
+++ b/src/ableton_cli/commands/browser.py
@@ -12,6 +12,10 @@ browser_app = typer.Typer(help="Ableton browser commands", no_args_is_help=True)
 
 def _resolve_browser_target(target: str) -> tuple[str | None, str | None]:
     parsed = require_non_empty_string("target", target, hint="Pass a non-empty target.")
+    first_colon = parsed.find(":")
+    first_slash = parsed.find("/")
+    if first_colon >= 0 and (first_slash < 0 or first_colon < first_slash):
+        return parsed, None
     if "/" in parsed:
         return None, parsed
     if ":" in parsed:

--- a/tests/test_cli_new_commands.py
+++ b/tests/test_cli_new_commands.py
@@ -1093,6 +1093,30 @@ def test_browser_load_supports_uri_and_path_target(runner, cli_app, monkeypatch)
     assert path_payload["result"]["uri"] is None
 
 
+def test_browser_load_treats_uri_with_slash_as_uri(runner, cli_app, monkeypatch) -> None:
+    from ableton_cli.commands import browser
+
+    monkeypatch.setattr(browser, "get_client", lambda ctx: _ClientStub())
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "0",
+            "query:LivePacks#www.ableton.com/272:Drum%20Racks:Fuji%20Kit.adg",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["result"]["uri"] == "query:LivePacks#www.ableton.com/272:Drum%20Racks:Fuji%20Kit.adg"
+    assert payload["result"]["path"] is None
+
+
 def test_browser_load_supports_target_track_mode_clip_slot_and_preserve_track_name(
     runner,
     cli_app,


### PR DESCRIPTION
## 概要
`browser load` が `query:.../..` 形式のURIをパスとして誤判定していた問題を修正しました。

## ユーザー影響
`browser items` / `browser items-at-path` が返すURIをそのまま `browser load` に渡すと `INVALID_ARGUMENT` になり、検索結果からのロード自動化が壊れていました。

## 根本原因
CLI側の `_resolve_browser_target` が `"/"` を `":"` より先に判定しており、`query:LivePacks#.../..` のようにスラッシュを含むURIを常にパスとして扱っていました。

## 修正内容
- URI/パス判定を見直し、最初の `":"` が最初の `"/"` より前にある場合はURIとして扱うように変更。
- `query:LivePacks#www.ableton.com/272:...` のような実例フォーマットをCLIテストに追加。

## テスト
- `uv run pytest -q tests/test_cli_new_commands.py -k "browser_load_supports_uri_and_path_target or uri_with_slash_as_uri"`
- `uv run pytest -q tests/test_cli_new_commands.py tests/test_cli_validation.py`

Closes #18
