### PR TITLE
[codex] fix midi clip placement for browser load existing mode

### DIFF
--- a/remote_script/AbletonCliRemote/live_backend_parts/browser.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/browser.py
@@ -328,6 +328,134 @@ class LiveBackendBrowserReadMixin:
             )
         return clip_slot
 
+    @staticmethod
+    def _is_midi_clip_browser_item(item: Any) -> bool:
+        name = str(getattr(item, "name", "")).strip().lower()
+        return bool(name.endswith(".alc"))
+
+    @staticmethod
+    def _created_tracks_since(
+        *,
+        before: list[Any],
+        after: list[Any],
+    ) -> list[tuple[int, Any]]:
+        before_ids = {id(track) for track in before}
+        return [
+            (index, track)
+            for index, track in enumerate(after)
+            if id(track) not in before_ids
+        ]
+
+    @staticmethod
+    def _first_track_clip(track: Any) -> tuple[int, Any] | None:
+        for slot_index, slot in enumerate(list(getattr(track, "clip_slots", []))):
+            if not bool(getattr(slot, "has_clip", False)):
+                continue
+            clip_obj = getattr(slot, "clip", None)
+            if clip_obj is not None:
+                return slot_index, clip_obj
+        return None
+
+    def _replace_clip_notes(self, *, source_clip: Any, target_clip: Any) -> None:
+        source_notes = list(self._clip_notes_extended(source_clip))
+        existing_notes = list(self._clip_notes_extended(target_clip))
+        note_ids_to_remove = [int(note["note_id"]) for note in existing_notes]
+        remove_notes_by_id = getattr(target_clip, "remove_notes_by_id", None)
+        if note_ids_to_remove and callable(remove_notes_by_id):
+            remove_notes_by_id(note_ids_to_remove)
+        set_notes = getattr(target_clip, "set_notes", None)
+        if not callable(set_notes):
+            raise _not_supported_by_live_api(
+                message="Clip note write API is not available in Live API",
+                hint="Use a Live version exposing clip.set_notes for MIDI clips.",
+            )
+        set_notes(
+            tuple(
+                (
+                    int(note["pitch"]),
+                    float(note["start_time"]),
+                    float(note["duration"]),
+                    int(note["velocity"]),
+                    bool(note["mute"]),
+                )
+                for note in source_notes
+            )
+        )
+
+    def _rehome_loaded_midi_clip_if_needed(
+        self,
+        *,
+        song: Any,
+        item: Any,
+        target_track: Any,
+        target_track_mode: str,
+        clip_slot: int | None,
+        tracks_before_load: list[Any],
+    ) -> None:
+        if target_track_mode != "existing":
+            return
+        if clip_slot is None:
+            return
+        if not self._is_midi_clip_browser_item(item):
+            return
+
+        tracks_after_load = list(getattr(song, "tracks", []))
+        created_tracks = self._created_tracks_since(
+            before=tracks_before_load,
+            after=tracks_after_load,
+        )
+        if not created_tracks:
+            return
+        if len(created_tracks) != 1:
+            raise _invalid_argument(
+                message="Clip load created an unexpected number of tracks",
+                hint="Retry with a deterministic MIDI clip target track and slot.",
+            )
+
+        source_track_index, source_track = created_tracks[0]
+        source_clip_entry = self._first_track_clip(source_track)
+        if source_clip_entry is None:
+            raise _invalid_argument(
+                message="Loaded clip track did not contain a clip",
+                hint="Retry with a loadable MIDI clip target.",
+            )
+        _source_slot_index, source_clip = source_clip_entry
+
+        target_slots = list(getattr(target_track, "clip_slots", []))
+        if clip_slot < 0 or clip_slot >= len(target_slots):
+            raise _invalid_argument(
+                message=f"clip_slot out of range after load: {clip_slot}",
+                hint="Use a valid clip slot index for the target track.",
+            )
+        target_slot = target_slots[clip_slot]
+        if not bool(getattr(target_slot, "has_clip", False)):
+            create_clip = getattr(target_slot, "create_clip", None)
+            if not callable(create_clip):
+                raise _not_supported_by_live_api(
+                    message="Clip creation API is not available in Live API",
+                    hint="Use a Live version exposing clip_slot.create_clip.",
+                )
+            source_length = max(float(getattr(source_clip, "length", 1.0)), 0.000001)
+            create_clip(source_length)
+        target_clip = getattr(target_slot, "clip", None)
+        if target_clip is None:
+            raise _invalid_argument(
+                message="Target clip slot did not contain a clip after creation",
+                hint="Retry with an existing or creatable MIDI clip slot.",
+            )
+
+        self._replace_clip_notes(source_clip=source_clip, target_clip=target_clip)
+        if hasattr(target_clip, "name"):
+            target_clip.name = str(getattr(source_clip, "name", ""))
+
+        delete_track = getattr(song, "delete_track", None)
+        if not callable(delete_track):
+            raise _not_supported_by_live_api(
+                message="Track delete API is not available in Live API",
+                hint="Use a Live version exposing song.delete_track.",
+            )
+        delete_track(source_track_index)
+
     def load_instrument_or_effect(
         self,
         track: int,
@@ -369,6 +497,7 @@ class LiveBackendBrowserReadMixin:
             uri = serialized["uri"]
 
         song = self._song()
+        tracks_before_load = list(getattr(song, "tracks", []))
         track_count_before = len(list(getattr(song, "tracks", [])))
         target, resolved_track = self._resolve_load_target_track(
             track=track,
@@ -382,6 +511,14 @@ class LiveBackendBrowserReadMixin:
             clip_slot=clip_slot,
         )
         self._browser().load_item(item)
+        self._rehome_loaded_midi_clip_if_needed(
+            song=song,
+            item=item,
+            target_track=target,
+            target_track_mode=target_track_mode,
+            clip_slot=resolved_clip_slot,
+            tracks_before_load=tracks_before_load,
+        )
         if track_name_before is not None and hasattr(target, "name"):
             target.name = track_name_before
         track_count_after = len(list(getattr(song, "tracks", [])))

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -859,6 +859,46 @@ def test_live_backend_load_existing_mode_targets_clip_slot_and_preserves_track_n
     assert target_track.clip_slots[1].has_clip is True
 
 
+def test_live_backend_load_existing_mode_rehomes_clip_when_live_creates_new_track() -> None:
+    surface = _SurfaceStub()
+    browser = surface.application().browser
+    original_load_item = browser.load_item
+
+    def _load_item_force_new_track(item: _BrowserItem) -> None:
+        uri = str(getattr(item, "uri", ""))
+        if uri != "clip:bass-loop-alc":
+            original_load_item(item)
+            return
+        new_track = _Track(name="Imported Clip", has_audio_input=False, has_midi_input=True)
+        source_slot = new_track.clip_slots[0]
+        source_slot.create_clip(length=2.0)
+        assert source_slot.clip is not None
+        source_slot.clip.set_notes(((60, 0.0, 0.5, 100, False),))
+        surface.song().tracks.append(new_track)
+
+    browser.load_item = _load_item_force_new_track  # type: ignore[method-assign]
+
+    backend = LiveBackend(surface)
+    loaded = backend.load_instrument_or_effect(
+        0,
+        uri=None,
+        path="sounds/Bass Loop.alc",
+        target_track_mode="existing",
+        clip_slot=1,
+        preserve_track_name=True,
+    )
+
+    assert loaded["loaded"] is True
+    assert loaded["track"] == 0
+    assert loaded["clip_slot"] == 1
+    assert loaded["track_count_delta"] == 0
+    assert loaded["track_count"] == 2
+    assert loaded["track_name"] == "Track 1"
+    assert surface.song().tracks[0].clip_slots[1].has_clip is True
+    notes = backend.get_clip_notes(0, 1, None, None, None)
+    assert notes["note_count"] == 1
+
+
 def test_live_backend_load_existing_mode_rejects_invalid_clip_slot() -> None:
     backend = LiveBackend(_SurfaceStub())
 


### PR DESCRIPTION
## 概要
`browser load --target-track-mode existing --clip-slot <n>` で MIDI Clip (`.alc`) を読み込む際、Live側が新規トラックを作成してしまうケースを補正し、最終的に既存トラック/指定スロットへ配置されるようにしました。

## ユーザー影響
シーン配置用にPackのMIDIクリップを既存トラックへ置きたい場面で、意図せず新規トラックが増えてワークフローが崩れていました。

## 根本原因
`load_item` 実行後の状態を検証せず、Live側が `.alc` ロード時に作成した新規トラックをそのまま受け入れていたため、`target-track-mode=existing` が保証されていませんでした。

## 修正内容
- `.alc` を `existing + clip-slot` で読み込む際に、ロード前後のトラック差分を検出。
- 新規トラックが作成された場合は、そのトラック上のクリップ内容（ノート）を指定スロットへ移し替え。
- 移し替え後に追加トラックを削除して、`track_count_delta` が 0 になるように整合。
- 既存トラック名保持（`--preserve-track-name`）の挙動は維持。
- 回帰テストとして「Liveが新規トラックを作る挙動」をスタブで再現し、補正後の結果を固定。

## テスト
- `uv run pytest -q tests/test_live_backend.py -k "rehomes_clip_when_live_creates_new_track or load_existing_mode_targets_clip_slot_and_preserves_track_name or load_existing_mode_rejects_invalid_clip_slot"`
- `uv run pytest -q tests/test_live_backend.py tests/test_cli_new_commands.py`

Closes #19
