### PR TITLE
[codex] add browser load notes import mode for midi clips

### DIFF
--- a/remote_script/AbletonCliRemote/command_backend_contract.py
+++ b/remote_script/AbletonCliRemote/command_backend_contract.py
@@ -217,6 +217,7 @@ class _BrowserBackend(Protocol):
         target_track_mode: str,
         clip_slot: int | None,
         preserve_track_name: bool,
+        notes_mode: str | None,
     ) -> dict[str, Any]: ...
 
     def get_browser_tree(self, category_type: str) -> dict[str, Any]: ...

--- a/remote_script/AbletonCliRemote/command_backend_handlers_browser.py
+++ b/remote_script/AbletonCliRemote/command_backend_handlers_browser.py
@@ -17,6 +17,7 @@ from .command_backend_validators import (
 Handler = Callable[[CommandBackend, dict[str, Any]], dict[str, Any]]
 _ALLOWED_ITEM_TYPES = frozenset({"all", "folder", "device", "loadable"})
 _ALLOWED_TARGET_TRACK_MODES = frozenset({"auto", "existing", "new"})
+_ALLOWED_NOTES_MODES = frozenset({"replace", "append"})
 
 
 def _parse_target_track_mode(args: dict[str, Any]) -> str:
@@ -36,6 +37,19 @@ def _parse_optional_clip_slot(args: dict[str, Any]) -> int | None:
     return _non_negative_int("clip_slot", raw)
 
 
+def _parse_optional_notes_mode(args: dict[str, Any]) -> str | None:
+    raw = args.get("notes_mode")
+    if raw is None:
+        return None
+    parsed = _non_empty_string("notes_mode", raw).lower()
+    if parsed not in _ALLOWED_NOTES_MODES:
+        raise _invalid_argument(
+            message=f"notes_mode must be one of replace/append, got {parsed}",
+            hint="Use notes_mode replace or append.",
+        )
+    return parsed
+
+
 def _handle_load_instrument_or_effect(
     backend: CommandBackend,
     args: dict[str, Any],
@@ -49,6 +63,7 @@ def _handle_load_instrument_or_effect(
     )
     target_track_mode = _parse_target_track_mode(args)
     clip_slot = _parse_optional_clip_slot(args)
+    notes_mode = _parse_optional_notes_mode(args)
     preserve_track_name = _as_bool("preserve_track_name", args.get("preserve_track_name", False))
     return backend.load_instrument_or_effect(
         track,
@@ -57,6 +72,7 @@ def _handle_load_instrument_or_effect(
         target_track_mode,
         clip_slot,
         preserve_track_name,
+        notes_mode,
     )
 
 

--- a/remote_script/AbletonCliRemote/live_backend_parts/browser.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/browser.py
@@ -356,31 +356,129 @@ class LiveBackendBrowserReadMixin:
                 return slot_index, clip_obj
         return None
 
-    def _replace_clip_notes(self, *, source_clip: Any, target_clip: Any) -> None:
+    @staticmethod
+    def _clip_note_tuples(notes: list[dict[str, Any]]) -> tuple[tuple[int, float, float, int, bool], ...]:
+        return tuple(
+            (
+                int(note["pitch"]),
+                float(note["start_time"]),
+                float(note["duration"]),
+                int(note["velocity"]),
+                bool(note["mute"]),
+            )
+            for note in notes
+        )
+
+    def _import_clip_notes(
+        self,
+        *,
+        source_clip: Any,
+        target_clip: Any,
+        notes_mode: str,
+    ) -> int:
         source_notes = list(self._clip_notes_extended(source_clip))
-        existing_notes = list(self._clip_notes_extended(target_clip))
-        note_ids_to_remove = [int(note["note_id"]) for note in existing_notes]
-        remove_notes_by_id = getattr(target_clip, "remove_notes_by_id", None)
-        if note_ids_to_remove and callable(remove_notes_by_id):
-            remove_notes_by_id(note_ids_to_remove)
+        if notes_mode == "replace":
+            existing_notes = list(self._clip_notes_extended(target_clip))
+            note_ids_to_remove = [int(note["note_id"]) for note in existing_notes]
+            remove_notes_by_id = getattr(target_clip, "remove_notes_by_id", None)
+            if note_ids_to_remove and callable(remove_notes_by_id):
+                remove_notes_by_id(note_ids_to_remove)
+        elif notes_mode != "append":
+            raise _invalid_argument(
+                message=f"notes_mode must be one of replace/append, got {notes_mode}",
+                hint="Use notes_mode replace or append.",
+            )
+
         set_notes = getattr(target_clip, "set_notes", None)
         if not callable(set_notes):
             raise _not_supported_by_live_api(
                 message="Clip note write API is not available in Live API",
                 hint="Use a Live version exposing clip.set_notes for MIDI clips.",
             )
-        set_notes(
-            tuple(
-                (
-                    int(note["pitch"]),
-                    float(note["start_time"]),
-                    float(note["duration"]),
-                    int(note["velocity"]),
-                    bool(note["mute"]),
-                )
-                for note in source_notes
+        note_payload = self._clip_note_tuples(source_notes)
+        if note_payload:
+            set_notes(note_payload)
+        return len(note_payload)
+
+    @staticmethod
+    def _delete_track(song: Any, track_index: int) -> None:
+        delete_track = getattr(song, "delete_track", None)
+        if not callable(delete_track):
+            raise _not_supported_by_live_api(
+                message="Track delete API is not available in Live API",
+                hint="Use a Live version exposing song.delete_track.",
             )
+        delete_track(track_index)
+
+    def _target_clip_for_import(
+        self,
+        *,
+        target_track: Any,
+        clip_slot: int,
+        source_clip: Any,
+        require_existing_clip: bool,
+    ) -> Any:
+        target_slots = list(getattr(target_track, "clip_slots", []))
+        if clip_slot < 0 or clip_slot >= len(target_slots):
+            raise _invalid_argument(
+                message=f"clip_slot out of range after load: {clip_slot}",
+                hint="Use a valid clip slot index for the target track.",
+            )
+        target_slot = target_slots[clip_slot]
+        if not bool(getattr(target_slot, "has_clip", False)):
+            if require_existing_clip:
+                raise _invalid_argument(
+                    message="No clip in slot",
+                    hint="Create a clip before importing browser MIDI notes.",
+                )
+            create_clip = getattr(target_slot, "create_clip", None)
+            if not callable(create_clip):
+                raise _not_supported_by_live_api(
+                    message="Clip creation API is not available in Live API",
+                    hint="Use a Live version exposing clip_slot.create_clip.",
+                )
+            source_length = max(float(getattr(source_clip, "length", 1.0)), 0.000001)
+            create_clip(source_length)
+        target_clip = getattr(target_slot, "clip", None)
+        if target_clip is None:
+            raise _invalid_argument(
+                message="Target clip slot did not contain a clip after creation",
+                hint="Retry with an existing or creatable MIDI clip slot.",
+            )
+        return target_clip
+
+    def _load_midi_clip_to_temporary_track(self, *, song: Any, item: Any) -> tuple[int, Any]:
+        tracks_before_load = list(getattr(song, "tracks", []))
+        view = getattr(song, "view", None)
+        had_selected_scene = bool(view is not None and hasattr(view, "selected_scene"))
+        previous_selected_scene = getattr(view, "selected_scene", None) if had_selected_scene else None
+        if had_selected_scene:
+            view.selected_scene = None
+        try:
+            self._browser().load_item(item)
+        finally:
+            if had_selected_scene:
+                view.selected_scene = previous_selected_scene
+
+        tracks_after_load = list(getattr(song, "tracks", []))
+        created_tracks = self._created_tracks_since(
+            before=tracks_before_load,
+            after=tracks_after_load,
         )
+        if len(created_tracks) != 1:
+            raise _invalid_argument(
+                message="MIDI clip import did not create a deterministic source track",
+                hint="Retry with a loadable .alc target from browser items/search.",
+            )
+        source_track_index, source_track = created_tracks[0]
+        source_clip_entry = self._first_track_clip(source_track)
+        if source_clip_entry is None:
+            raise _invalid_argument(
+                message="Imported source track did not contain a clip",
+                hint="Retry with a loadable MIDI clip target.",
+            )
+        _source_slot_index, source_clip = source_clip_entry
+        return source_track_index, source_clip
 
     def _rehome_loaded_midi_clip_if_needed(
         self,
@@ -391,13 +489,13 @@ class LiveBackendBrowserReadMixin:
         target_track_mode: str,
         clip_slot: int | None,
         tracks_before_load: list[Any],
-    ) -> None:
+    ) -> int | None:
         if target_track_mode != "existing":
-            return
+            return None
         if clip_slot is None:
-            return
+            return None
         if not self._is_midi_clip_browser_item(item):
-            return
+            return None
 
         tracks_after_load = list(getattr(song, "tracks", []))
         created_tracks = self._created_tracks_since(
@@ -405,7 +503,7 @@ class LiveBackendBrowserReadMixin:
             after=tracks_after_load,
         )
         if not created_tracks:
-            return
+            return None
         if len(created_tracks) != 1:
             raise _invalid_argument(
                 message="Clip load created an unexpected number of tracks",
@@ -421,40 +519,22 @@ class LiveBackendBrowserReadMixin:
             )
         _source_slot_index, source_clip = source_clip_entry
 
-        target_slots = list(getattr(target_track, "clip_slots", []))
-        if clip_slot < 0 or clip_slot >= len(target_slots):
-            raise _invalid_argument(
-                message=f"clip_slot out of range after load: {clip_slot}",
-                hint="Use a valid clip slot index for the target track.",
-            )
-        target_slot = target_slots[clip_slot]
-        if not bool(getattr(target_slot, "has_clip", False)):
-            create_clip = getattr(target_slot, "create_clip", None)
-            if not callable(create_clip):
-                raise _not_supported_by_live_api(
-                    message="Clip creation API is not available in Live API",
-                    hint="Use a Live version exposing clip_slot.create_clip.",
-                )
-            source_length = max(float(getattr(source_clip, "length", 1.0)), 0.000001)
-            create_clip(source_length)
-        target_clip = getattr(target_slot, "clip", None)
-        if target_clip is None:
-            raise _invalid_argument(
-                message="Target clip slot did not contain a clip after creation",
-                hint="Retry with an existing or creatable MIDI clip slot.",
-            )
-
-        self._replace_clip_notes(source_clip=source_clip, target_clip=target_clip)
+        target_clip = self._target_clip_for_import(
+            target_track=target_track,
+            clip_slot=clip_slot,
+            source_clip=source_clip,
+            require_existing_clip=False,
+        )
+        imported_note_count = self._import_clip_notes(
+            source_clip=source_clip,
+            target_clip=target_clip,
+            notes_mode="replace",
+        )
         if hasattr(target_clip, "name"):
             target_clip.name = str(getattr(source_clip, "name", ""))
 
-        delete_track = getattr(song, "delete_track", None)
-        if not callable(delete_track):
-            raise _not_supported_by_live_api(
-                message="Track delete API is not available in Live API",
-                hint="Use a Live version exposing song.delete_track.",
-            )
-        delete_track(source_track_index)
+        self._delete_track(song, source_track_index)
+        return imported_note_count
 
     def load_instrument_or_effect(
         self,
@@ -464,6 +544,7 @@ class LiveBackendBrowserReadMixin:
         target_track_mode: str = "auto",
         clip_slot: int | None = None,
         preserve_track_name: bool = False,
+        notes_mode: str | None = None,
     ) -> dict[str, Any]:
         if uri is None and path is None:
             raise _invalid_argument(
@@ -496,6 +577,13 @@ class LiveBackendBrowserReadMixin:
                 )
             uri = serialized["uri"]
 
+        resolved_notes_mode = notes_mode.lower() if isinstance(notes_mode, str) else None
+        if resolved_notes_mode is not None and resolved_notes_mode not in {"replace", "append"}:
+            raise _invalid_argument(
+                message=f"notes_mode must be one of replace/append, got {notes_mode}",
+                hint="Use notes_mode replace or append.",
+            )
+
         song = self._song()
         tracks_before_load = list(getattr(song, "tracks", []))
         track_count_before = len(list(getattr(song, "tracks", [])))
@@ -510,15 +598,58 @@ class LiveBackendBrowserReadMixin:
             target_track=target,
             clip_slot=clip_slot,
         )
-        self._browser().load_item(item)
-        self._rehome_loaded_midi_clip_if_needed(
-            song=song,
-            item=item,
-            target_track=target,
-            target_track_mode=target_track_mode,
-            clip_slot=resolved_clip_slot,
-            tracks_before_load=tracks_before_load,
-        )
+        imported_note_count: int | None = None
+        length_imported: bool | None = None
+        groove_imported: bool | None = None
+        if resolved_notes_mode is None:
+            self._browser().load_item(item)
+            imported_note_count = self._rehome_loaded_midi_clip_if_needed(
+                song=song,
+                item=item,
+                target_track=target,
+                target_track_mode=target_track_mode,
+                clip_slot=resolved_clip_slot,
+                tracks_before_load=tracks_before_load,
+            )
+        else:
+            if target_track_mode != "existing":
+                raise _invalid_argument(
+                    message="notes_mode requires target_track_mode=existing",
+                    hint="Use --target-track-mode existing when importing notes.",
+                )
+            if resolved_clip_slot is None:
+                raise _invalid_argument(
+                    message="notes_mode requires clip_slot",
+                    hint="Use --clip-slot to select the destination clip.",
+                )
+            if not self._is_midi_clip_browser_item(item):
+                raise _invalid_argument(
+                    message="notes_mode is supported only for MIDI clip (.alc) browser items",
+                    hint="Choose a .alc target from browser search/items.",
+                )
+            source_track_index, source_clip = self._load_midi_clip_to_temporary_track(
+                song=song,
+                item=item,
+            )
+            try:
+                target_clip = self._target_clip_for_import(
+                    target_track=target,
+                    clip_slot=resolved_clip_slot,
+                    source_clip=source_clip,
+                    require_existing_clip=True,
+                )
+                imported_note_count = self._import_clip_notes(
+                    source_clip=source_clip,
+                    target_clip=target_clip,
+                    notes_mode=resolved_notes_mode,
+                )
+                if hasattr(target_clip, "name"):
+                    target_clip.name = str(getattr(source_clip, "name", ""))
+            finally:
+                self._delete_track(song, source_track_index)
+            length_imported = False
+            groove_imported = False
+
         if track_name_before is not None and hasattr(target, "name"):
             target.name = track_name_before
         track_count_after = len(list(getattr(song, "tracks", [])))
@@ -532,6 +663,10 @@ class LiveBackendBrowserReadMixin:
             "clip_slot": resolved_clip_slot,
             "target_track_mode": target_track_mode,
             "preserve_track_name": preserve_track_name,
+            "notes_mode": resolved_notes_mode,
+            "notes_imported": imported_note_count,
+            "length_imported": length_imported,
+            "groove_imported": groove_imported,
             "track_name": str(getattr(target, "name", "")),
             "track_count": track_count_after,
             "track_count_delta": track_count_after - track_count_before,

--- a/src/ableton_cli/client/_client_browser_scenes.py
+++ b/src/ableton_cli/client/_client_browser_scenes.py
@@ -12,6 +12,7 @@ class _AbletonClientBrowserScenesMixin:
         target_track_mode: str = "auto",
         clip_slot: int | None = None,
         preserve_track_name: bool = False,
+        notes_mode: str | None = None,
     ) -> dict[str, Any]:
         args: dict[str, Any] = {
             "track": track,
@@ -21,6 +22,7 @@ class _AbletonClientBrowserScenesMixin:
         self._add_if_not_none(args, "uri", uri)
         self._add_if_not_none(args, "path", path)
         self._add_if_not_none(args, "clip_slot", clip_slot)
+        self._add_if_not_none(args, "notes_mode", notes_mode)
         return self._call("load_instrument_or_effect", args)
 
     def get_browser_tree(self, category_type: str = "all") -> dict[str, Any]:

--- a/src/ableton_cli/commands/browser.py
+++ b/src/ableton_cli/commands/browser.py
@@ -211,6 +211,13 @@ def browser_load(
         int | None,
         typer.Option("--clip-slot", help="Clip slot (scene index, 0-based)"),
     ] = None,
+    notes_mode: Annotated[
+        str | None,
+        typer.Option(
+            "--notes-mode",
+            help="Import .alc notes into the target clip using replace|append",
+        ),
+    ] = None,
     preserve_track_name: Annotated[
         bool,
         typer.Option("--preserve-track-name", help="Restore original track name after loading"),
@@ -243,6 +250,20 @@ def browser_load(
             if clip_slot is not None
             else None
         )
+        valid_notes_mode = (
+            require_non_empty_string(
+                "notes_mode",
+                notes_mode,
+                hint="Use --notes-mode replace or append.",
+            ).lower()
+            if notes_mode is not None
+            else None
+        )
+        if valid_notes_mode is not None and valid_notes_mode not in {"replace", "append"}:
+            raise invalid_argument(
+                message=f"notes_mode must be one of replace/append, got {notes_mode}",
+                hint="Use --notes-mode replace or append.",
+            )
         valid_uri, valid_path = _resolve_browser_target(target)
         return get_client(ctx).load_instrument_or_effect(
             track,
@@ -250,6 +271,7 @@ def browser_load(
             path=valid_path,
             target_track_mode=valid_mode,
             clip_slot=valid_clip_slot,
+            notes_mode=valid_notes_mode,
             preserve_track_name=preserve_track_name,
         )
 
@@ -261,6 +283,7 @@ def browser_load(
             "target": target,
             "target_track_mode": target_track_mode,
             "clip_slot": clip_slot,
+            "notes_mode": notes_mode,
             "preserve_track_name": preserve_track_name,
         },
         action=_run,

--- a/tests/test_cli_new_commands.py
+++ b/tests/test_cli_new_commands.py
@@ -291,6 +291,7 @@ class _ClientStub:
         target_track_mode: str = "auto",
         clip_slot: int | None = None,
         preserve_track_name: bool = False,
+        notes_mode: str | None = None,
     ):
         return {
             "track": track,
@@ -299,6 +300,7 @@ class _ClientStub:
             "target_track_mode": target_track_mode,
             "clip_slot": clip_slot,
             "preserve_track_name": preserve_track_name,
+            "notes_mode": notes_mode,
             "loaded": True,
         }
 
@@ -1150,6 +1152,36 @@ def test_browser_load_supports_target_track_mode_clip_slot_and_preserve_track_na
     assert payload["result"]["target_track_mode"] == "existing"
     assert payload["result"]["clip_slot"] == 3
     assert payload["result"]["preserve_track_name"] is True
+
+
+def test_browser_load_supports_notes_mode(runner, cli_app, monkeypatch) -> None:
+    from ableton_cli.commands import browser
+
+    monkeypatch.setattr(browser, "get_client", lambda ctx: _ClientStub())
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "1",
+            "sounds/Bass Loop.alc",
+            "--target-track-mode",
+            "existing",
+            "--clip-slot",
+            "2",
+            "--notes-mode",
+            "append",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["result"]["notes_mode"] == "append"
+    assert payload["result"]["clip_slot"] == 2
 
 
 def test_browser_load_drum_kit_supports_kit_uri_or_path(runner, cli_app, monkeypatch) -> None:

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -380,6 +380,30 @@ def test_browser_load_rejects_negative_clip_slot(runner, cli_app) -> None:
     assert payload["error"]["code"] == "INVALID_ARGUMENT"
 
 
+def test_browser_load_rejects_invalid_notes_mode(runner, cli_app) -> None:
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "0",
+            "sounds/Bass Loop.alc",
+            "--target-track-mode",
+            "existing",
+            "--clip-slot",
+            "1",
+            "--notes-mode",
+            "merge",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "INVALID_ARGUMENT"
+
+
 def test_browser_load_drum_kit_requires_exactly_one_kit_selector(runner, cli_app) -> None:
     none_selected = runner.invoke(
         cli_app,

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -899,6 +899,82 @@ def test_live_backend_load_existing_mode_rehomes_clip_when_live_creates_new_trac
     assert notes["note_count"] == 1
 
 
+@pytest.mark.parametrize(
+    ("notes_mode", "expected_pitches"),
+    (
+        ("replace", [60]),
+        ("append", [60, 72]),
+    ),
+)
+def test_live_backend_load_existing_mode_notes_mode_imports_into_existing_clip(
+    notes_mode: str,
+    expected_pitches: list[int],
+) -> None:
+    surface = _SurfaceStub()
+    target_slot = surface.song().tracks[0].clip_slots[1]
+    target_slot.create_clip(length=2.0)
+    assert target_slot.clip is not None
+    target_slot.clip.set_notes(((72, 0.25, 0.5, 90, False),))
+
+    browser = surface.application().browser
+    original_load_item = browser.load_item
+
+    def _load_item_force_new_track(item: _BrowserItem) -> None:
+        uri = str(getattr(item, "uri", ""))
+        if uri != "clip:bass-loop-alc":
+            original_load_item(item)
+            return
+        new_track = _Track(name="Imported Clip", has_audio_input=False, has_midi_input=True)
+        source_slot = new_track.clip_slots[0]
+        source_slot.create_clip(length=2.0)
+        assert source_slot.clip is not None
+        source_slot.clip.set_notes(((60, 0.0, 0.5, 100, False),))
+        surface.song().tracks.append(new_track)
+
+    browser.load_item = _load_item_force_new_track  # type: ignore[method-assign]
+
+    backend = LiveBackend(surface)
+    loaded = backend.load_instrument_or_effect(
+        0,
+        uri=None,
+        path="sounds/Bass Loop.alc",
+        target_track_mode="existing",
+        clip_slot=1,
+        preserve_track_name=True,
+        notes_mode=notes_mode,
+    )
+
+    assert loaded["loaded"] is True
+    assert loaded["track"] == 0
+    assert loaded["clip_slot"] == 1
+    assert loaded["track_count_delta"] == 0
+    assert loaded["track_count"] == 2
+    assert loaded["track_name"] == "Track 1"
+    assert loaded["notes_mode"] == notes_mode
+    assert loaded["notes_imported"] == 1
+    assert loaded["length_imported"] is False
+    assert loaded["groove_imported"] is False
+    notes = backend.get_clip_notes(0, 1, None, None, None)
+    assert sorted(note["pitch"] for note in notes["notes"]) == expected_pitches
+
+
+def test_live_backend_load_notes_mode_requires_existing_clip() -> None:
+    backend = LiveBackend(_SurfaceStub())
+
+    with pytest.raises(CommandError) as exc_info:
+        backend.load_instrument_or_effect(
+            0,
+            uri=None,
+            path="sounds/Bass Loop.alc",
+            target_track_mode="existing",
+            clip_slot=1,
+            preserve_track_name=False,
+            notes_mode="replace",
+        )
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
+
+
 def test_live_backend_load_existing_mode_rejects_invalid_clip_slot() -> None:
     backend = LiveBackend(_SurfaceStub())
 

--- a/tests/test_remote_command_backend.py
+++ b/tests/test_remote_command_backend.py
@@ -292,6 +292,7 @@ class _BackendStub:
         target_track_mode: str,
         clip_slot: int | None,
         preserve_track_name: bool,
+        notes_mode: str | None,
     ):
         return {
             "track": track,
@@ -300,6 +301,7 @@ class _BackendStub:
             "target_track_mode": target_track_mode,
             "clip_slot": clip_slot,
             "preserve_track_name": preserve_track_name,
+            "notes_mode": notes_mode,
             "loaded": True,
         }
 
@@ -859,6 +861,7 @@ def test_dispatch_calls_backend_for_browser_load_with_path() -> None:
         "target_track_mode": "auto",
         "clip_slot": None,
         "preserve_track_name": False,
+        "notes_mode": None,
         "loaded": True,
     }
 
@@ -883,6 +886,32 @@ def test_dispatch_calls_backend_for_browser_load_with_existing_mode_and_clip_slo
         "target_track_mode": "existing",
         "clip_slot": 3,
         "preserve_track_name": True,
+        "notes_mode": None,
+        "loaded": True,
+    }
+
+
+def test_dispatch_calls_backend_for_browser_load_with_notes_mode() -> None:
+    backend = _BackendStub()
+    result = dispatch_command(
+        backend,
+        "load_instrument_or_effect",
+        {
+            "track": 1,
+            "path": "sounds/Bass Loop.alc",
+            "target_track_mode": "existing",
+            "clip_slot": 2,
+            "notes_mode": "append",
+        },
+    )
+    assert result == {
+        "track": 1,
+        "uri": None,
+        "path": "sounds/Bass Loop.alc",
+        "target_track_mode": "existing",
+        "clip_slot": 2,
+        "preserve_track_name": False,
+        "notes_mode": "append",
         "loaded": True,
     }
 
@@ -1417,6 +1446,24 @@ def test_dispatch_rejects_browser_load_with_negative_clip_slot() -> None:
                 "track": 0,
                 "path": "instruments/Drift",
                 "clip_slot": -1,
+            },
+        )
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
+
+
+def test_dispatch_rejects_browser_load_with_invalid_notes_mode() -> None:
+    backend = _BackendStub()
+    with pytest.raises(CommandError) as exc_info:
+        dispatch_command(
+            backend,
+            "load_instrument_or_effect",
+            {
+                "track": 0,
+                "path": "sounds/Bass Loop.alc",
+                "target_track_mode": "existing",
+                "clip_slot": 1,
+                "notes_mode": "merge",
             },
         )
 


### PR DESCRIPTION
## 概要
Pack MIDI Clip (`.alc`) のノートを既存クリップへ取り込むため、`browser load` に `--notes-mode` を追加しました。

## ユーザー影響
従来は `.alc` 取り込み時に新規トラック作成に引きずられやすく、既存クリップへのノート展開（置換/追記）をCLIだけで安定実行しにくい状態でした。

## 根本原因
`browser load` は「デバイス/クリップをロードする」処理のみで、既存クリップへのノート移送モードを持っておらず、`.alc` のノート活用ワークフローが明示的に表現できませんでした。

## 修正内容
- `browser load` に `--notes-mode replace|append` を追加。
- `--notes-mode` 指定時は `.alc` のみ受け付け、`target-track-mode=existing` と `clip-slot` を必須化。
- 一時的に生成されたソースクリップからノートを抽出し、対象クリップへ
  - `replace`: 既存ノート置換
  - `append`: 既存ノートへ追記
  で反映。
- 処理後に一時トラックを削除して、最終的な `track_count_delta` を 0 に維持。
- レスポンスに以下を追加し、取り込み可否を明示:
  - `notes_mode`
  - `notes_imported`
  - `length_imported` (現時点では `false`)
  - `groove_imported` (現時点では `false`)
- CLI/クライアント/リモートハンドラの引数伝播とバリデーションを更新。

## テスト
- `uv run pytest -q tests/test_cli_validation.py tests/test_cli_new_commands.py tests/test_remote_command_backend.py tests/test_live_backend.py`

Closes #20
