### PR TITLE
[codex] add multi-slot clip duplicate placements

### DIFF
--- a/remote_script/AbletonCliRemote/command_backend_contract.py
+++ b/remote_script/AbletonCliRemote/command_backend_contract.py
@@ -187,7 +187,13 @@ class _TracksClipsBackend(Protocol):
 
     def clip_active_set(self, track: int, clip: int, value: bool) -> dict[str, Any]: ...
 
-    def clip_duplicate(self, track: int, src_clip: int, dst_clip: int) -> dict[str, Any]: ...
+    def clip_duplicate(
+        self,
+        track: int,
+        src_clip: int,
+        dst_clip: int | None,
+        dst_clips: list[int] | None,
+    ) -> dict[str, Any]: ...
 
     def scenes_list(self) -> dict[str, Any]: ...
 

--- a/remote_script/AbletonCliRemote/command_backend_handlers_tracks_clips.py
+++ b/remote_script/AbletonCliRemote/command_backend_handlers_tracks_clips.py
@@ -11,6 +11,7 @@ from .command_backend_validators import (
     _clip_notes_filter,
     _clip_quantize_grid,
     _humanize_velocity_amount,
+    _invalid_argument,
     _insert_index,
     _non_empty_string,
     _non_negative_float,
@@ -153,8 +154,49 @@ def _handle_stop_clip(backend: CommandBackend, args: dict[str, Any]) -> dict[str
 def _handle_clip_duplicate(backend: CommandBackend, args: dict[str, Any]) -> dict[str, Any]:
     track = _track_index("track", args.get("track"))
     src_clip = _track_index("src_clip", args.get("src_clip"))
-    dst_clip = _track_index("dst_clip", args.get("dst_clip"))
-    return backend.clip_duplicate(track, src_clip, dst_clip)
+    dst_clip_raw = args.get("dst_clip")
+    dst_clips_raw = args.get("dst_clips")
+    if dst_clip_raw is None and dst_clips_raw is None:
+        raise _invalid_argument(
+            message="Either dst_clip or dst_clips must be provided",
+            hint="Provide one destination clip slot or multiple destination clip slots.",
+        )
+    if dst_clip_raw is not None and dst_clips_raw is not None:
+        raise _invalid_argument(
+            message="dst_clip and dst_clips are mutually exclusive",
+            hint="Provide either dst_clip or dst_clips.",
+        )
+    if dst_clip_raw is not None:
+        dst_clip = _track_index("dst_clip", dst_clip_raw)
+        return backend.clip_duplicate(track, src_clip, dst_clip, None)
+
+    if not isinstance(dst_clips_raw, list):
+        raise _invalid_argument(
+            message="dst_clips must be an array of clip indexes",
+            hint="Pass dst_clips as a list of non-negative integers.",
+        )
+    if not dst_clips_raw:
+        raise _invalid_argument(
+            message="dst_clips must not be empty",
+            hint="Pass at least one destination clip index.",
+        )
+    parsed_dst_clips: list[int] = []
+    seen: set[int] = set()
+    for index, value in enumerate(dst_clips_raw):
+        parsed_value = _track_index(f"dst_clips[{index}]", value)
+        if parsed_value == src_clip:
+            raise _invalid_argument(
+                message=f"dst_clips[{index}] must differ from src_clip ({src_clip})",
+                hint="Use destination clip slots that are not the source clip.",
+            )
+        if parsed_value in seen:
+            raise _invalid_argument(
+                message=f"dst_clips[{index}] duplicates clip index {parsed_value}",
+                hint="Remove duplicate destination clip indexes.",
+            )
+        seen.add(parsed_value)
+        parsed_dst_clips.append(parsed_value)
+    return backend.clip_duplicate(track, src_clip, None, parsed_dst_clips)
 
 
 def _handle_clip_active_get(backend: CommandBackend, args: dict[str, Any]) -> dict[str, Any]:

--- a/remote_script/AbletonCliRemote/live_backend_parts/tracks_clips.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/tracks_clips.py
@@ -628,19 +628,58 @@ class LiveBackendTracksClipsMixin:
             "active": not bool(clip_obj.muted),
         }
 
-    def clip_duplicate(self, track: int, src_clip: int, dst_clip: int) -> dict[str, Any]:
+    def _duplicate_clip_to_destination(
+        self,
+        *,
+        track: int,
+        destination_clip: int,
+        source_clip: Any,
+        source_length: float,
+        live_notes: list[tuple[int, float, float, int, bool]],
+    ) -> None:
+        destination_slot = self._clip_slot_at(track, destination_clip)
+        if destination_slot.has_clip:
+            raise _invalid_argument(
+                message=f"Destination clip slot already has a clip: {destination_clip}",
+                hint="Use empty destination clip slots.",
+            )
+
+        destination_slot.create_clip(source_length)
+        if not destination_slot.has_clip:
+            raise CommandError(
+                code="INTERNAL_ERROR",
+                message="Clip duplication did not create destination clip",
+                hint="Retry and check Ableton logs.",
+            )
+        destination_clip_obj = destination_slot.clip
+        assert destination_clip_obj is not None
+        if live_notes:
+            destination_clip_obj.set_notes(tuple(live_notes))
+        destination_clip_obj.name = str(getattr(source_clip, "name", ""))
+
+    def clip_duplicate(
+        self,
+        track: int,
+        src_clip: int,
+        dst_clip: int | None = None,
+        dst_clips: list[int] | None = None,
+    ) -> dict[str, Any]:
+        if dst_clip is None and dst_clips is None:
+            raise _invalid_argument(
+                message="Either dst_clip or dst_clips must be provided",
+                hint="Provide one destination clip slot or multiple destination clip slots.",
+            )
+        if dst_clip is not None and dst_clips is not None:
+            raise _invalid_argument(
+                message="dst_clip and dst_clips are mutually exclusive",
+                hint="Provide either dst_clip or dst_clips.",
+            )
+
         source_slot = self._clip_slot_at(track, src_clip)
         if not source_slot.has_clip:
             raise _invalid_argument(
                 message="Source clip does not exist",
                 hint="Create a clip in the source slot before duplicating.",
-            )
-
-        destination_slot = self._clip_slot_at(track, dst_clip)
-        if destination_slot.has_clip:
-            raise _invalid_argument(
-                message="Destination clip slot already has a clip",
-                hint="Use an empty destination clip slot.",
             )
 
         source_clip = source_slot.clip
@@ -651,16 +690,6 @@ class LiveBackendTracksClipsMixin:
                 message="Source clip length must be > 0",
                 hint="Duplicate only clips with positive length.",
             )
-
-        destination_slot.create_clip(source_length)
-        if not destination_slot.has_clip:
-            raise CommandError(
-                code="INTERNAL_ERROR",
-                message="Clip duplication did not create destination clip",
-                hint="Retry and check Ableton logs.",
-            )
-        destination_clip = destination_slot.clip
-        assert destination_clip is not None
 
         source_notes = self._clip_notes_extended(source_clip)
         live_notes = [
@@ -673,14 +702,46 @@ class LiveBackendTracksClipsMixin:
             )
             for note in source_notes
         ]
-        if live_notes:
-            destination_clip.set_notes(tuple(live_notes))
-        destination_clip.name = str(getattr(source_clip, "name", ""))
+        destination_clips = [dst_clip] if dst_clip is not None else list(dst_clips or [])
+        if not destination_clips:
+            raise _invalid_argument(
+                message="dst_clips must not be empty",
+                hint="Pass at least one destination clip index.",
+            )
+        seen: set[int] = set()
+        for destination in destination_clips:
+            if destination == src_clip:
+                raise _invalid_argument(
+                    message=f"Destination clip index must differ from src_clip ({src_clip})",
+                    hint="Use destination clip slots that are not the source clip.",
+                )
+            if destination in seen:
+                raise _invalid_argument(
+                    message=f"Duplicate destination clip index: {destination}",
+                    hint="Remove duplicate destination clip indexes.",
+                )
+            seen.add(destination)
+            self._duplicate_clip_to_destination(
+                track=track,
+                destination_clip=destination,
+                source_clip=source_clip,
+                source_length=source_length,
+                live_notes=live_notes,
+            )
 
+        if len(destination_clips) == 1:
+            return {
+                "track": track,
+                "src_clip": src_clip,
+                "dst_clip": destination_clips[0],
+                "duplicated": True,
+                "note_count": len(live_notes),
+            }
         return {
             "track": track,
             "src_clip": src_clip,
-            "dst_clip": dst_clip,
+            "dst_clips": destination_clips,
             "duplicated": True,
+            "duplicated_count": len(destination_clips),
             "note_count": len(live_notes),
         }

--- a/src/ableton_cli/client/_client_tracks_clips.py
+++ b/src/ableton_cli/client/_client_tracks_clips.py
@@ -257,11 +257,17 @@ class _AbletonClientTracksClipsMixin:
             {"track": track, "clip": clip, "value": value},
         )
 
-    def clip_duplicate(self, track: int, src_clip: int, dst_clip: int) -> dict[str, Any]:
-        return self._call(
-            "clip_duplicate",
-            {"track": track, "src_clip": src_clip, "dst_clip": dst_clip},
-        )
+    def clip_duplicate(
+        self,
+        track: int,
+        src_clip: int,
+        dst_clip: int | None = None,
+        dst_clips: list[int] | None = None,
+    ) -> dict[str, Any]:
+        args: dict[str, Any] = {"track": track, "src_clip": src_clip}
+        self._add_if_not_none(args, "dst_clip", dst_clip)
+        self._add_if_not_none(args, "dst_clips", dst_clips)
+        return self._call("clip_duplicate", args)
 
     def execute_batch(self, steps: list[dict[str, Any]]) -> dict[str, Any]:
         return self._call("execute_batch", {"steps": steps})

--- a/src/ableton_cli/commands/clip.py
+++ b/src/ableton_cli/commands/clip.py
@@ -111,6 +111,72 @@ def _require_uri_or_path_target(target: str) -> str:
     )
 
 
+def _parse_duplicate_destinations(
+    *,
+    src_clip: int,
+    dst_clip: int | None,
+    to: str | None,
+) -> tuple[int | None, list[int] | None]:
+    if dst_clip is None and to is None:
+        raise invalid_argument(
+            message="Either dst_clip or --to must be provided",
+            hint="Provide one destination clip slot or --to 2,4,5.",
+        )
+    if dst_clip is not None and to is not None:
+        raise invalid_argument(
+            message="dst_clip and --to are mutually exclusive",
+            hint="Use either a single dst_clip argument or --to for multiple destinations.",
+        )
+    if dst_clip is not None:
+        return (
+            require_non_negative(
+                "dst_clip",
+                dst_clip,
+                hint="Use a valid destination clip slot index.",
+            ),
+            None,
+        )
+
+    assert to is not None
+    parsed = require_non_empty_string("to", to, hint="Use comma-separated clip slots like 2,4,5.")
+    destinations: list[int] = []
+    seen: set[int] = set()
+    for raw_value in parsed.split(","):
+        token = raw_value.strip()
+        if not token:
+            continue
+        try:
+            value = int(token)
+        except ValueError as exc:
+            raise invalid_argument(
+                message=f"Invalid destination clip index in --to: {token!r}",
+                hint="Use comma-separated non-negative integers like 2,4,5.",
+            ) from exc
+        if value < 0:
+            raise invalid_argument(
+                message=f"Destination clip index must be >= 0, got {value}",
+                hint="Use non-negative destination clip indexes.",
+            )
+        if value == src_clip:
+            raise invalid_argument(
+                message=f"Destination clip index must differ from src_clip ({src_clip})",
+                hint="Use destination indexes that are not the source clip.",
+            )
+        if value in seen:
+            raise invalid_argument(
+                message=f"Duplicate destination clip index in --to: {value}",
+                hint="Remove duplicated destination indexes.",
+            )
+        seen.add(value)
+        destinations.append(value)
+    if not destinations:
+        raise invalid_argument(
+            message="--to must include at least one destination clip index",
+            hint="Use comma-separated indexes like --to 2,4,5.",
+        )
+    return None, destinations
+
+
 @clip_app.command("create")
 def clip_create(
     ctx: typer.Context,
@@ -814,7 +880,14 @@ def clip_duplicate(
     ctx: typer.Context,
     track: Annotated[int, typer.Argument(help="Track index (0-based)")],
     src_clip: Annotated[int, typer.Argument(help="Source clip slot index (0-based)")],
-    dst_clip: Annotated[int, typer.Argument(help="Destination clip slot index (0-based)")],
+    dst_clip: Annotated[
+        int | None,
+        typer.Argument(help="Destination clip slot index (0-based)"),
+    ] = None,
+    to: Annotated[
+        str | None,
+        typer.Option("--to", help="Comma-separated destination clip slot indexes (0-based)"),
+    ] = None,
 ) -> None:
     def _run() -> dict[str, object]:
         require_non_negative(
@@ -827,17 +900,22 @@ def clip_duplicate(
             src_clip,
             hint="Use a valid source clip slot index.",
         )
-        require_non_negative(
-            "dst_clip",
-            dst_clip,
-            hint="Use a valid destination clip slot index.",
+        single_dst_clip, many_dst_clips = _parse_duplicate_destinations(
+            src_clip=src_clip,
+            dst_clip=dst_clip,
+            to=to,
         )
-        return get_client(ctx).clip_duplicate(track, src_clip, dst_clip)
+        return get_client(ctx).clip_duplicate(
+            track=track,
+            src_clip=src_clip,
+            dst_clip=single_dst_clip,
+            dst_clips=many_dst_clips,
+        )
 
     execute_command(
         ctx,
         command="clip duplicate",
-        args={"track": track, "src_clip": src_clip, "dst_clip": dst_clip},
+        args={"track": track, "src_clip": src_clip, "dst_clip": dst_clip, "to": to},
         action=_run,
     )
 

--- a/tests/test_cli_new_commands.py
+++ b/tests/test_cli_new_commands.py
@@ -103,8 +103,21 @@ class _ClientStub:
             "added_count": len(notes),
         }
 
-    def clip_duplicate(self, track: int, src_clip: int, dst_clip: int):  # noqa: ANN201
-        return {"track": track, "src_clip": src_clip, "dst_clip": dst_clip, "duplicated": True}
+    def clip_duplicate(  # noqa: ANN201
+        self,
+        track: int,
+        src_clip: int,
+        dst_clip: int | None = None,
+        dst_clips: list[int] | None = None,
+    ):
+        if dst_clip is not None:
+            return {"track": track, "src_clip": src_clip, "dst_clip": dst_clip, "duplicated": True}
+        return {
+            "track": track,
+            "src_clip": src_clip,
+            "dst_clips": dst_clips or [],
+            "duplicated": True,
+        }
 
     def clip_notes_quantize(  # noqa: ANN201
         self,
@@ -1295,6 +1308,26 @@ def test_clip_duplicate_command_outputs_json_envelope(runner, cli_app, monkeypat
     payload = json.loads(duplicated.stdout)
     assert payload["ok"] is True
     assert payload["result"] == {"track": 0, "src_clip": 1, "dst_clip": 2, "duplicated": True}
+
+
+def test_clip_duplicate_supports_multiple_destinations(runner, cli_app, monkeypatch) -> None:
+    from ableton_cli.commands import clip
+
+    monkeypatch.setattr(clip, "get_client", lambda ctx: _ClientStub())
+
+    duplicated = runner.invoke(
+        cli_app,
+        ["--output", "json", "clip", "duplicate", "0", "1", "--to", "2,4,5"],
+    )
+    assert duplicated.exit_code == 0
+    payload = json.loads(duplicated.stdout)
+    assert payload["ok"] is True
+    assert payload["result"] == {
+        "track": 0,
+        "src_clip": 1,
+        "dst_clips": [2, 4, 5],
+        "duplicated": True,
+    }
 
 
 def test_clip_active_commands_output_json_envelope(runner, cli_app, monkeypatch) -> None:

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -431,6 +431,17 @@ def test_browser_load_drum_kit_requires_exactly_one_kit_selector(runner, cli_app
     assert json.loads(both_selected.stdout)["error"]["code"] == "INVALID_ARGUMENT"
 
 
+def test_clip_duplicate_rejects_invalid_to_list(runner, cli_app) -> None:
+    result = runner.invoke(
+        cli_app,
+        ["--output", "json", "clip", "duplicate", "0", "1", "--to", "1,2"],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "INVALID_ARGUMENT"
+
+
 def test_clip_notes_filters_reject_invalid_range(runner, cli_app) -> None:
     result = runner.invoke(
         cli_app,

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -1437,6 +1437,28 @@ def test_live_backend_clip_duplicate() -> None:
     assert occupied_dst.value.code == "INVALID_ARGUMENT"
 
 
+def test_live_backend_clip_duplicate_many() -> None:
+    surface = _SurfaceStub()
+    surface.song().tracks[0].clip_slots.append(_ClipSlot())
+    backend = LiveBackend(surface)
+    backend.create_clip(0, 0, 4.0)
+    backend.add_notes_to_clip(0, 0, [_note()])
+
+    duplicated = backend.clip_duplicate(track=0, src_clip=0, dst_clips=[1, 2])
+    assert duplicated == {
+        "track": 0,
+        "src_clip": 0,
+        "dst_clips": [1, 2],
+        "duplicated": True,
+        "duplicated_count": 2,
+        "note_count": 1,
+    }
+    duplicated_notes_1 = backend.get_clip_notes(0, 1, None, None, None)
+    duplicated_notes_2 = backend.get_clip_notes(0, 2, None, None, None)
+    assert duplicated_notes_1["note_count"] == 1
+    assert duplicated_notes_2["note_count"] == 1
+
+
 def test_live_backend_tracks_delete_and_not_supported_error() -> None:
     backend = LiveBackend(_SurfaceStub())
     deleted = backend.tracks_delete(0)

--- a/tests/test_remote_command_backend.py
+++ b/tests/test_remote_command_backend.py
@@ -154,8 +154,21 @@ class _BackendStub:
     def clip_active_set(self, track: int, clip: int, value: bool):  # noqa: ANN201
         return {"track": track, "clip": clip, "active": value}
 
-    def clip_duplicate(self, track: int, src_clip: int, dst_clip: int):  # noqa: ANN201
-        return {"track": track, "src_clip": src_clip, "dst_clip": dst_clip, "duplicated": True}
+    def clip_duplicate(  # noqa: ANN201
+        self,
+        track: int,
+        src_clip: int,
+        dst_clip: int | None,
+        dst_clips: list[int] | None,
+    ):
+        if dst_clip is not None:
+            return {"track": track, "src_clip": src_clip, "dst_clip": dst_clip, "duplicated": True}
+        return {
+            "track": track,
+            "src_clip": src_clip,
+            "dst_clips": dst_clips or [],
+            "duplicated": True,
+        }
 
     def clip_notes_quantize(  # noqa: ANN201
         self,
@@ -1128,6 +1141,23 @@ def test_dispatch_calls_backend_for_new_todo_commands() -> None:
     assert tracks_delete == {"track": 0, "deleted": True}
 
 
+def test_dispatch_calls_backend_for_clip_duplicate_many() -> None:
+    backend = _BackendStub()
+
+    duplicate_many = dispatch_command(
+        backend,
+        "clip_duplicate",
+        {"track": 1, "src_clip": 2, "dst_clips": [3, 4, 5]},
+    )
+
+    assert duplicate_many == {
+        "track": 1,
+        "src_clip": 2,
+        "dst_clips": [3, 4, 5],
+        "duplicated": True,
+    }
+
+
 def test_dispatch_calls_backend_for_clip_note_transform_commands() -> None:
     backend = _BackendStub()
 
@@ -1220,6 +1250,18 @@ def test_dispatch_validates_new_todo_command_arguments() -> None:
             "clip_duplicate",
             {"track": 0, "src_clip": 1, "dst_clip": -1},
         )
+    with pytest.raises(CommandError) as clip_duplicate_conflict_exc:
+        dispatch_command(
+            backend,
+            "clip_duplicate",
+            {"track": 0, "src_clip": 1, "dst_clip": 2, "dst_clips": [3]},
+        )
+    with pytest.raises(CommandError) as clip_duplicate_missing_dst_exc:
+        dispatch_command(
+            backend,
+            "clip_duplicate",
+            {"track": 0, "src_clip": 1},
+        )
     with pytest.raises(CommandError) as clip_active_set_exc:
         dispatch_command(
             backend,
@@ -1234,6 +1276,8 @@ def test_dispatch_validates_new_todo_command_arguments() -> None:
     assert song_save_exc.value.code == "INVALID_ARGUMENT"
     assert song_export_exc.value.code == "INVALID_ARGUMENT"
     assert clip_duplicate_exc.value.code == "INVALID_ARGUMENT"
+    assert clip_duplicate_conflict_exc.value.code == "INVALID_ARGUMENT"
+    assert clip_duplicate_missing_dst_exc.value.code == "INVALID_ARGUMENT"
     assert clip_active_set_exc.value.code == "INVALID_ARGUMENT"
     assert scenes_move_exc.value.code == "INVALID_ARGUMENT"
     assert tracks_delete_exc.value.code == "INVALID_ARGUMENT"


### PR DESCRIPTION
## 概要
`clip duplicate` を拡張し、単一複製に加えて複数スロットへの一括複製をサポートしました。

## ユーザー影響
従来はシーン配置を増やすたびに `clip duplicate` を繰り返し実行する必要があり、8〜16シーン規模の配置作業が冗長でした。

## 根本原因
`clip duplicate` が単一の `dst_clip` しか受け付けず、複数スロットを一度に指定する手段がありませんでした。

## 修正内容
- CLI: `clip duplicate` に `--to` オプションを追加。
  - 例: `clip duplicate 0 1 --to 2,4,5`
- 検証ルール:
  - `dst_clip` と `--to` は同時指定不可
  - いずれか必須
  - `--to` は空不可・重複不可・`src_clip` と同値不可
- クライアント/リモートハンドラ/バックエンドを更新し、`dst_clips` 配列を受けて一括複製を実行。
- 単一複製の従来挙動・レスポンス形式は維持。
- 一括複製時は `dst_clips` と `duplicated_count` を返却。

## テスト
- `uv run pytest -q tests/test_cli_new_commands.py tests/test_cli_validation.py tests/test_remote_command_backend.py tests/test_live_backend.py tests/test_ableton_client.py`
- `uv run pytest -q`

Closes #21
