### PR TITLE
[codex] #18 browser load URI 正規化を強化

### DIFF
--- a/remote_script/AbletonCliRemote/live_backend_parts/browser.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/browser.py
@@ -31,7 +31,13 @@ class LiveBackendBrowserCatalogMixin:
         return text
 
     def _normalize_uri(self, value: str) -> str:
-        return unquote(value.strip())
+        normalized = value.strip()
+        for _ in range(4):
+            decoded = unquote(normalized)
+            if decoded == normalized:
+                break
+            normalized = decoded
+        return normalized
 
     def _uri_matches(self, candidate: Any, expected: str) -> bool:
         candidate_uri = self._coerce_uri(candidate)

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -725,6 +725,20 @@ def test_live_backend_browser_uri_lookup_normalizes_percent_encoding() -> None:
     assert load["loaded"] is True
 
 
+def test_live_backend_browser_uri_lookup_normalizes_nested_percent_encoding() -> None:
+    surface = _SurfaceStub()
+    surface.application().browser.instruments.children[
+        0
+    ].uri = "query:LivePacks#www.ableton.com/272:Drum%2520Racks:Fuji%2520Kit.adg"
+    backend = LiveBackend(surface)
+
+    resolved_uri = "query:LivePacks#www.ableton.com/272:Drum%20Racks:Fuji%20Kit.adg"
+    item = backend.get_browser_item(uri=resolved_uri, path=None)
+    assert item["found"] is True
+    load = backend.load_instrument_or_effect(0, uri=resolved_uri, path=None)
+    assert load["loaded"] is True
+
+
 def test_live_backend_browser_unknown_uri_is_deterministic_without_fallback() -> None:
     backend = LiveBackend(_SurfaceStub())
     uri = "query:Synths#Missing-Device"


### PR DESCRIPTION
## 概要
Fixes #18

`browser items*` が返す URI を `browser load` にそのまま渡したとき、URI が多重に percent-encode されているケースで一致判定に失敗し、`INVALID_ARGUMENT` になっていました。

## 何が問題だったか
- URI 比較の正規化が `unquote` 1回だけだったため、`%2520` のような値を含む URI で一致しませんでした。
- その結果、`browser item/items` の結果をそのまま `browser load` に渡せず、検索→ロードの自動化が壊れていました。

## 対応内容
- `remote_script/.../browser.py` の URI 正規化を多段デコードに変更しました。
- デコード結果が変わらなくなるまで（上限付きで）正規化し、`%2520` / `%20` / スペース表記の差を吸収して一致判定できるようにしました。
- `tests/test_live_backend.py` に再現テストを追加しました。

## ユーザー影響
- `browser items*` が返した URI をそのまま `browser load` に渡しても、エンコード段数の違いで失敗しにくくなります。
- CLI での deterministic な「検索→ロード」自動化が安定します。

## テスト
- `uv run pytest tests/test_live_backend.py -k "browser_uri_lookup_normalizes" -q`
- `uv run pytest tests/test_live_backend.py -k "browser and not search" -q`
- `uv run pytest tests/test_cli_new_commands.py -k "browser_load_treats_uri_with_slash_as_uri or browser_load_supports_uri_and_path_target" -q`
- `uv run pytest tests/test_remote_command_backend.py -k "browser_load" -q`
