### PR TITLE
[codex] #19 existing mode の MIDI Clip 配置を安定化

### DIFF
--- a/remote_script/AbletonCliRemote/live_backend_parts/browser.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/browser.py
@@ -359,6 +359,51 @@ class LiveBackendBrowserReadMixin:
         return None
 
     @staticmethod
+    def _scene_index(song: Any, scene_obj: Any) -> int | None:
+        for index, scene in enumerate(list(getattr(song, "scenes", []))):
+            if scene is scene_obj:
+                return index
+        return None
+
+    def _selected_scene_index(self, *, song: Any) -> int | None:
+        view = getattr(song, "view", None)
+        if view is None or not hasattr(view, "selected_scene"):
+            return None
+        selected_scene = getattr(view, "selected_scene", None)
+        if selected_scene is None:
+            return None
+        return self._scene_index(song, selected_scene)
+
+    def _resolve_rehome_clip_slot(
+        self,
+        *,
+        song: Any,
+        target_track: Any,
+        clip_slot: int | None,
+    ) -> int:
+        if clip_slot is not None:
+            return clip_slot
+
+        selected_scene_index = self._selected_scene_index(song=song)
+        if selected_scene_index is None:
+            raise _invalid_argument(
+                message="clip_slot is required when selected scene is unavailable",
+                hint=(
+                    "Pass --clip-slot when using target_track_mode=existing for MIDI clip targets."
+                ),
+            )
+
+        target_slots = list(getattr(target_track, "clip_slots", []))
+        if selected_scene_index < 0 or selected_scene_index >= len(target_slots):
+            raise _invalid_argument(
+                message=(
+                    f"selected scene index out of range for target track: {selected_scene_index}"
+                ),
+                hint="Use --clip-slot to choose a valid destination clip slot.",
+            )
+        return selected_scene_index
+
+    @staticmethod
     def _clip_note_tuples(
         notes: list[dict[str, Any]],
     ) -> tuple[tuple[int, float, float, int, bool], ...]:
@@ -453,25 +498,46 @@ class LiveBackendBrowserReadMixin:
 
     def _load_midi_clip_to_temporary_track(self, *, song: Any, item: Any) -> tuple[int, Any]:
         tracks_before_load = list(getattr(song, "tracks", []))
+        create_midi_track = getattr(song, "create_midi_track", None)
+        if not callable(create_midi_track):
+            raise _not_supported_by_live_api(
+                message="Track creation API is not available in Live API",
+                hint="Use a Live version exposing song.create_midi_track.",
+            )
+        temporary_track_index = len(tracks_before_load)
+        create_midi_track(-1)
+        temporary_track = self._track_at(temporary_track_index)
+
         view = getattr(song, "view", None)
-        had_selected_scene = bool(view is not None and hasattr(view, "selected_scene"))
-        previous_selected_scene = (
-            getattr(view, "selected_scene", None) if had_selected_scene else None
+        previous_selected_track = (
+            getattr(view, "selected_track", None)
+            if view is not None and hasattr(view, "selected_track")
+            else None
         )
-        if had_selected_scene:
-            view.selected_scene = None
+        self._select_track_for_load(song=song, target_track=temporary_track)
         try:
             self._browser().load_item(item)
         finally:
-            if had_selected_scene:
-                view.selected_scene = previous_selected_scene
+            if previous_selected_track is not None and view is not None:
+                view.selected_track = previous_selected_track
+
+        source_clip_entry = self._first_track_clip(temporary_track)
+        if source_clip_entry is not None:
+            _source_slot_index, source_clip = source_clip_entry
+            return temporary_track_index, source_clip
 
         tracks_after_load = list(getattr(song, "tracks", []))
-        created_tracks = self._created_tracks_since(
+        created_tracks_including_temporary = self._created_tracks_since(
             before=tracks_before_load,
             after=tracks_after_load,
         )
+        created_tracks = [
+            (index, track)
+            for index, track in created_tracks_including_temporary
+            if id(track) != id(temporary_track)
+        ]
         if len(created_tracks) != 1:
+            self._delete_track(song, temporary_track_index)
             raise _invalid_argument(
                 message="MIDI clip import did not create a deterministic source track",
                 hint="Retry with a loadable .alc target from browser items/search.",
@@ -479,10 +545,14 @@ class LiveBackendBrowserReadMixin:
         source_track_index, source_track = created_tracks[0]
         source_clip_entry = self._first_track_clip(source_track)
         if source_clip_entry is None:
+            self._delete_track(song, temporary_track_index)
             raise _invalid_argument(
                 message="Imported source track did not contain a clip",
                 hint="Retry with a loadable MIDI clip target.",
             )
+        self._delete_track(song, temporary_track_index)
+        if source_track_index > temporary_track_index:
+            source_track_index -= 1
         _source_slot_index, source_clip = source_clip_entry
         return source_track_index, source_clip
 
@@ -495,10 +565,8 @@ class LiveBackendBrowserReadMixin:
         target_track_mode: str,
         clip_slot: int | None,
         tracks_before_load: list[Any],
-    ) -> int | None:
+    ) -> tuple[int, int] | None:
         if target_track_mode != "existing":
-            return None
-        if clip_slot is None:
             return None
         if not self._is_midi_clip_browser_item(item):
             return None
@@ -525,9 +593,14 @@ class LiveBackendBrowserReadMixin:
             )
         _source_slot_index, source_clip = source_clip_entry
 
-        target_clip = self._target_clip_for_import(
+        destination_clip_slot = self._resolve_rehome_clip_slot(
+            song=song,
             target_track=target_track,
             clip_slot=clip_slot,
+        )
+        target_clip = self._target_clip_for_import(
+            target_track=target_track,
+            clip_slot=destination_clip_slot,
             source_clip=source_clip,
             require_existing_clip=False,
         )
@@ -540,7 +613,7 @@ class LiveBackendBrowserReadMixin:
             target_clip.name = str(getattr(source_clip, "name", ""))
 
         self._delete_track(song, source_track_index)
-        return imported_note_count
+        return imported_note_count, destination_clip_slot
 
     def load_instrument_or_effect(
         self,
@@ -609,7 +682,7 @@ class LiveBackendBrowserReadMixin:
         groove_imported: bool | None = None
         if resolved_notes_mode is None:
             self._browser().load_item(item)
-            imported_note_count = self._rehome_loaded_midi_clip_if_needed(
+            rehomed = self._rehome_loaded_midi_clip_if_needed(
                 song=song,
                 item=item,
                 target_track=target,
@@ -617,6 +690,8 @@ class LiveBackendBrowserReadMixin:
                 clip_slot=resolved_clip_slot,
                 tracks_before_load=tracks_before_load,
             )
+            if rehomed is not None:
+                imported_note_count, resolved_clip_slot = rehomed
         else:
             if target_track_mode != "existing":
                 raise _invalid_argument(

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -913,6 +913,46 @@ def test_live_backend_load_existing_mode_rehomes_clip_when_live_creates_new_trac
     assert notes["note_count"] == 1
 
 
+def test_live_backend_load_existing_mode_rehomes_clip_without_explicit_clip_slot() -> None:
+    surface = _SurfaceStub()
+    browser = surface.application().browser
+    original_load_item = browser.load_item
+
+    def _load_item_force_new_track(item: _BrowserItem) -> None:
+        uri = str(getattr(item, "uri", ""))
+        if uri != "clip:bass-loop-alc":
+            original_load_item(item)
+            return
+        new_track = _Track(name="Imported Clip", has_audio_input=False, has_midi_input=True)
+        source_slot = new_track.clip_slots[0]
+        source_slot.create_clip(length=2.0)
+        assert source_slot.clip is not None
+        source_slot.clip.set_notes(((60, 0.0, 0.5, 100, False),))
+        surface.song().tracks.append(new_track)
+
+    browser.load_item = _load_item_force_new_track  # type: ignore[method-assign]
+
+    backend = LiveBackend(surface)
+    loaded = backend.load_instrument_or_effect(
+        0,
+        uri=None,
+        path="sounds/Bass Loop.alc",
+        target_track_mode="existing",
+        clip_slot=None,
+        preserve_track_name=True,
+    )
+
+    assert loaded["loaded"] is True
+    assert loaded["track"] == 0
+    assert loaded["clip_slot"] == 0
+    assert loaded["track_count_delta"] == 0
+    assert loaded["track_count"] == 2
+    assert loaded["track_name"] == "Track 1"
+    assert surface.song().tracks[0].clip_slots[0].has_clip is True
+    notes = backend.get_clip_notes(0, 0, None, None, None)
+    assert notes["note_count"] == 1
+
+
 @pytest.mark.parametrize(
     ("notes_mode", "expected_pitches"),
     (
@@ -970,6 +1010,75 @@ def test_live_backend_load_existing_mode_notes_mode_imports_into_existing_clip(
     assert loaded["groove_imported"] is False
     notes = backend.get_clip_notes(0, 1, None, None, None)
     assert sorted(note["pitch"] for note in notes["notes"]) == expected_pitches
+
+
+def test_live_backend_load_notes_mode_does_not_require_selected_scene_none() -> None:
+    class _StrictSelectedSceneView:
+        def __init__(
+            self,
+            *,
+            selected_track: _Track,
+            selected_scene: _Scene,
+            highlighted_clip_slot: _ClipSlot | None,
+        ) -> None:
+            self.selected_track = selected_track
+            self._selected_scene = selected_scene
+            self.highlighted_clip_slot = highlighted_clip_slot
+
+        @property
+        def selected_scene(self) -> _Scene:
+            return self._selected_scene
+
+        @selected_scene.setter
+        def selected_scene(self, value: _Scene) -> None:
+            if value is None:
+                raise TypeError("selected_scene cannot be None")
+            self._selected_scene = value
+
+    surface = _SurfaceStub()
+    song = surface.song()
+    song.view = _StrictSelectedSceneView(
+        selected_track=song.tracks[0],
+        selected_scene=song.scenes[0],
+        highlighted_clip_slot=song.tracks[0].clip_slots[0],
+    )
+    target_slot = song.tracks[0].clip_slots[1]
+    target_slot.create_clip(length=2.0)
+    assert target_slot.clip is not None
+    target_slot.clip.set_notes(((72, 0.25, 0.5, 90, False),))
+
+    browser = surface.application().browser
+    original_load_item = browser.load_item
+
+    def _load_item_force_new_track(item: _BrowserItem) -> None:
+        uri = str(getattr(item, "uri", ""))
+        if uri != "clip:bass-loop-alc":
+            original_load_item(item)
+            return
+        new_track = _Track(name="Imported Clip", has_audio_input=False, has_midi_input=True)
+        source_slot = new_track.clip_slots[0]
+        source_slot.create_clip(length=2.0)
+        assert source_slot.clip is not None
+        source_slot.clip.set_notes(((60, 0.0, 0.5, 100, False),))
+        surface.song().tracks.append(new_track)
+
+    browser.load_item = _load_item_force_new_track  # type: ignore[method-assign]
+
+    backend = LiveBackend(surface)
+    loaded = backend.load_instrument_or_effect(
+        0,
+        uri=None,
+        path="sounds/Bass Loop.alc",
+        target_track_mode="existing",
+        clip_slot=1,
+        preserve_track_name=True,
+        notes_mode="replace",
+    )
+
+    assert loaded["loaded"] is True
+    assert loaded["track_count_delta"] == 0
+    notes = backend.get_clip_notes(0, 1, None, None, None)
+    assert sorted(note["pitch"] for note in notes["notes"]) == [60]
 
 
 def test_live_backend_load_notes_mode_requires_existing_clip() -> None:


### PR DESCRIPTION
## 概要
Fixes #19

`browser load --target-track-mode existing` で MIDI Clip (`.alc`) を扱う際に、以下2つの不具合がありました。

1. `--notes-mode` 利用時に環境によって `INTERNAL_ERROR` になる
2. `--clip-slot` 未指定だと、新規トラックが作られたままになりやすい

## 何が問題だったか
- `notes-mode` の内部処理で `song.view.selected_scene = None` を使っており、`None` を受け付けない Live API 実装で失敗していました。
- `existing` モードの再配置処理が `clip_slot` 指定時しか動かず、未指定時に Live 側が新規トラックを作ると後片付けできませんでした。

## 対応内容
- `.alc` ノート取り込み時は、一時 MIDI トラックを明示的に作成してロードする方式に変更しました。
  - `selected_scene=None` を使わないため、API差分による `INTERNAL_ERROR` を回避できます。
  - 一時トラックが不要になったら必ず削除し、最終的なトラック数を保ちます。
- `existing + MIDI clip` の再配置では、`--clip-slot` 未指定時に「現在選択中シーン」の slot を解決して再配置するようにしました。
  - これにより `track_count_delta` を 0 に保ちやすくなります。
- 回帰テストを追加しました。

## ユーザー影響
- `notes-mode` で環境依存の `INTERNAL_ERROR` が出にくくなります。
- `existing` 指定時に不要な新規トラックが残りにくくなり、Pack MIDI clip 配置フローが安定します。

## テスト
- `uv run pytest tests/test_live_backend.py -k "rehomes_clip_without_explicit_clip_slot or does_not_require_selected_scene_none or load_existing_mode_rehomes_clip_when_live_creates_new_track" -q`
- `uv run pytest tests/test_live_backend.py -k "browser or load_existing_mode or load_notes_mode" -q`
- `uv run pytest tests/test_cli_new_commands.py -k "browser_load" -q`
- `uv run pytest tests/test_remote_command_backend.py -k "browser_load" -q`
