### PR TITLE
[codex] #20 既存clipへの browser MIDIノート取込コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ uv run ableton-cli clip notes add 0 0 --notes-file ./notes.json
 uv run ableton-cli clip notes get 0 0 --start-time 0.0 --end-time 4.0 --pitch 60
 uv run ableton-cli clip notes clear 0 0 --start-time 0.0 --end-time 1.0
 uv run ableton-cli clip notes replace 0 0 --notes-json '[{"pitch":65,"start_time":0.25,"duration":0.5,"velocity":100,"mute":false}]' --start-time 0.0 --end-time 1.0
+uv run ableton-cli clip notes import-browser 0 1 "sounds/Bass Loop.alc" --mode replace --import-length --import-groove
 uv run ableton-cli clip name set 0 0 "Hook"
 uv run ableton-cli clip fire 0 0
 uv run ableton-cli clip stop 0 0
@@ -138,6 +139,7 @@ uv run ableton-cli browser item drums/Kits
 uv run ableton-cli browser search drift --item-type loadable
 uv run ableton-cli browser load 0 query:Synths#Operator
 uv run ableton-cli browser load 0 instruments/Drift
+uv run ableton-cli browser load 0 "sounds/Bass Loop.alc" --target-track-mode existing --clip-slot 1 --notes-mode replace --import-length --import-groove
 uv run ableton-cli browser load-drum-kit 0 rack:drums --kit-uri kit:acoustic
 uv run ableton-cli browser load-drum-kit 0 rack:drums --kit-path drums/Kits/Acoustic Kit
 uv run ableton-cli batch run --steps-file ./steps.json

--- a/remote_script/AbletonCliRemote/command_backend_contract.py
+++ b/remote_script/AbletonCliRemote/command_backend_contract.py
@@ -224,6 +224,8 @@ class _BrowserBackend(Protocol):
         clip_slot: int | None,
         preserve_track_name: bool,
         notes_mode: str | None,
+        import_length: bool,
+        import_groove: bool,
     ) -> dict[str, Any]: ...
 
     def get_browser_tree(self, category_type: str) -> dict[str, Any]: ...

--- a/remote_script/AbletonCliRemote/command_backend_handlers_browser.py
+++ b/remote_script/AbletonCliRemote/command_backend_handlers_browser.py
@@ -65,6 +65,8 @@ def _handle_load_instrument_or_effect(
     clip_slot = _parse_optional_clip_slot(args)
     notes_mode = _parse_optional_notes_mode(args)
     preserve_track_name = _as_bool("preserve_track_name", args.get("preserve_track_name", False))
+    import_length = _as_bool("import_length", args.get("import_length", False))
+    import_groove = _as_bool("import_groove", args.get("import_groove", False))
     return backend.load_instrument_or_effect(
         track,
         uri,
@@ -73,6 +75,8 @@ def _handle_load_instrument_or_effect(
         clip_slot,
         preserve_track_name,
         notes_mode,
+        import_length,
+        import_groove,
     )
 
 

--- a/remote_script/AbletonCliRemote/live_backend_parts/browser.py
+++ b/remote_script/AbletonCliRemote/live_backend_parts/browser.py
@@ -450,6 +450,49 @@ class LiveBackendBrowserReadMixin:
         return len(note_payload)
 
     @staticmethod
+    def _import_clip_length(*, source_clip: Any, target_clip: Any) -> bool:
+        if not hasattr(source_clip, "length") or not hasattr(target_clip, "length"):
+            return False
+        source_length = getattr(source_clip, "length", None)
+        if not isinstance(source_length, (int, float)):
+            return False
+        normalized_length = float(source_length)
+        if normalized_length <= 0:
+            return False
+        target_clip.length = normalized_length
+        return True
+
+    @staticmethod
+    def _import_clip_groove(*, source_clip: Any, target_clip: Any) -> bool:
+        imported = False
+        for attribute in ("groove", "groove_assignment"):
+            if not hasattr(source_clip, attribute) or not hasattr(target_clip, attribute):
+                continue
+            setattr(target_clip, attribute, getattr(source_clip, attribute))
+            imported = True
+            break
+
+        for attribute in ("groove_amount", "groove_amount_value"):
+            if not hasattr(source_clip, attribute) or not hasattr(target_clip, attribute):
+                continue
+            source_value = getattr(source_clip, attribute)
+            if isinstance(source_value, (int, float)):
+                setattr(target_clip, attribute, float(source_value))
+                imported = True
+            break
+
+        for attribute in (
+            "_ableton_cli_groove_uri",
+            "_ableton_cli_groove_path",
+            "_ableton_cli_groove_name",
+        ):
+            if not hasattr(source_clip, attribute):
+                continue
+            setattr(target_clip, attribute, getattr(source_clip, attribute))
+            imported = True
+        return imported
+
+    @staticmethod
     def _delete_track(song: Any, track_index: int) -> None:
         delete_track = getattr(song, "delete_track", None)
         if not callable(delete_track):
@@ -624,6 +667,8 @@ class LiveBackendBrowserReadMixin:
         clip_slot: int | None = None,
         preserve_track_name: bool = False,
         notes_mode: str | None = None,
+        import_length: bool = False,
+        import_groove: bool = False,
     ) -> dict[str, Any]:
         if uri is None and path is None:
             raise _invalid_argument(
@@ -661,6 +706,11 @@ class LiveBackendBrowserReadMixin:
             raise _invalid_argument(
                 message=f"notes_mode must be one of replace/append, got {notes_mode}",
                 hint="Use notes_mode replace or append.",
+            )
+        if resolved_notes_mode is None and (import_length or import_groove):
+            raise _invalid_argument(
+                message="import_length/import_groove require notes_mode",
+                hint="Use notes_mode replace or append when importing clip length/groove.",
             )
 
         song = self._song()
@@ -726,10 +776,18 @@ class LiveBackendBrowserReadMixin:
                 )
                 if hasattr(target_clip, "name"):
                     target_clip.name = str(getattr(source_clip, "name", ""))
+                length_imported = (
+                    self._import_clip_length(source_clip=source_clip, target_clip=target_clip)
+                    if import_length
+                    else False
+                )
+                groove_imported = (
+                    self._import_clip_groove(source_clip=source_clip, target_clip=target_clip)
+                    if import_groove
+                    else False
+                )
             finally:
                 self._delete_track(song, source_track_index)
-            length_imported = False
-            groove_imported = False
 
         if track_name_before is not None and hasattr(target, "name"):
             target.name = track_name_before
@@ -745,6 +803,8 @@ class LiveBackendBrowserReadMixin:
             "target_track_mode": target_track_mode,
             "preserve_track_name": preserve_track_name,
             "notes_mode": resolved_notes_mode,
+            "import_length": import_length,
+            "import_groove": import_groove,
             "notes_imported": imported_note_count,
             "length_imported": length_imported,
             "groove_imported": groove_imported,

--- a/src/ableton_cli/client/_client_browser_scenes.py
+++ b/src/ableton_cli/client/_client_browser_scenes.py
@@ -13,6 +13,8 @@ class _AbletonClientBrowserScenesMixin:
         clip_slot: int | None = None,
         preserve_track_name: bool = False,
         notes_mode: str | None = None,
+        import_length: bool | None = None,
+        import_groove: bool | None = None,
     ) -> dict[str, Any]:
         args: dict[str, Any] = {
             "track": track,
@@ -23,6 +25,8 @@ class _AbletonClientBrowserScenesMixin:
         self._add_if_not_none(args, "path", path)
         self._add_if_not_none(args, "clip_slot", clip_slot)
         self._add_if_not_none(args, "notes_mode", notes_mode)
+        self._add_if_not_none(args, "import_length", import_length)
+        self._add_if_not_none(args, "import_groove", import_groove)
         return self._call("load_instrument_or_effect", args)
 
     def get_browser_tree(self, category_type: str = "all") -> dict[str, Any]:

--- a/src/ableton_cli/commands/_validation.py
+++ b/src/ableton_cli/commands/_validation.py
@@ -43,6 +43,27 @@ def require_non_empty_string(name: str, value: str, *, hint: str) -> str:
     return stripped
 
 
+def resolve_uri_or_path_target(
+    *,
+    target: str,
+    name: str = "target",
+    hint: str = ("Use a browser path like instruments/Operator or URI like query:Synths#Operator."),
+) -> tuple[str | None, str | None]:
+    parsed = require_non_empty_string(name, target, hint=f"Pass a non-empty {name}.")
+    first_colon = parsed.find(":")
+    first_slash = parsed.find("/")
+    if first_colon >= 0 and (first_slash < 0 or first_colon < first_slash):
+        return parsed, None
+    if "/" in parsed:
+        return None, parsed
+    if ":" in parsed:
+        return parsed, None
+    raise invalid_argument(
+        message=f"{name} must include '/' (path) or ':' (uri), got {parsed!r}",
+        hint=hint,
+    )
+
+
 def validate_clip_note_filters(
     *,
     start_time: float | None,

--- a/src/ableton_cli/commands/browser.py
+++ b/src/ableton_cli/commands/browser.py
@@ -5,25 +5,14 @@ from typing import Annotated
 import typer
 
 from ..runtime import execute_command, get_client
-from ._validation import invalid_argument, require_non_empty_string, require_non_negative
+from ._validation import (
+    invalid_argument,
+    require_non_empty_string,
+    require_non_negative,
+    resolve_uri_or_path_target,
+)
 
 browser_app = typer.Typer(help="Ableton browser commands", no_args_is_help=True)
-
-
-def _resolve_browser_target(target: str) -> tuple[str | None, str | None]:
-    parsed = require_non_empty_string("target", target, hint="Pass a non-empty target.")
-    first_colon = parsed.find(":")
-    first_slash = parsed.find("/")
-    if first_colon >= 0 and (first_slash < 0 or first_colon < first_slash):
-        return parsed, None
-    if "/" in parsed:
-        return None, parsed
-    if ":" in parsed:
-        return parsed, None
-    raise invalid_argument(
-        message=f"target must include '/' (path) or ':' (uri), got {parsed!r}",
-        hint="Use a browser path like instruments/Operator or URI like query:Synths#Operator.",
-    )
 
 
 @browser_app.command("tree")
@@ -65,7 +54,7 @@ def browser_item(
     target: Annotated[str, typer.Argument(help="Browser target (URI or path)")],
 ) -> None:
     def _run() -> dict[str, object]:
-        valid_uri, valid_path = _resolve_browser_target(target)
+        valid_uri, valid_path = resolve_uri_or_path_target(target=target)
         return get_client(ctx).get_browser_item(uri=valid_uri, path=valid_path)
 
     execute_command(
@@ -222,6 +211,20 @@ def browser_load(
         bool,
         typer.Option("--preserve-track-name", help="Restore original track name after loading"),
     ] = False,
+    import_length: Annotated[
+        bool,
+        typer.Option(
+            "--import-length/--no-import-length",
+            help="When using --notes-mode, copy source clip length into the destination clip",
+        ),
+    ] = False,
+    import_groove: Annotated[
+        bool,
+        typer.Option(
+            "--import-groove/--no-import-groove",
+            help="When using --notes-mode, copy source clip groove settings",
+        ),
+    ] = False,
 ) -> None:
     def _run() -> dict[str, object]:
         require_non_negative(
@@ -264,7 +267,12 @@ def browser_load(
                 message=f"notes_mode must be one of replace/append, got {notes_mode}",
                 hint="Use --notes-mode replace or append.",
             )
-        valid_uri, valid_path = _resolve_browser_target(target)
+        if valid_notes_mode is None and (import_length or import_groove):
+            raise invalid_argument(
+                message="--import-length/--import-groove require --notes-mode",
+                hint="Use --notes-mode replace or append when importing clip length/groove.",
+            )
+        valid_uri, valid_path = resolve_uri_or_path_target(target=target)
         return get_client(ctx).load_instrument_or_effect(
             track,
             uri=valid_uri,
@@ -273,6 +281,8 @@ def browser_load(
             clip_slot=valid_clip_slot,
             notes_mode=valid_notes_mode,
             preserve_track_name=preserve_track_name,
+            import_length=import_length,
+            import_groove=import_groove,
         )
 
     execute_command(
@@ -285,6 +295,8 @@ def browser_load(
             "clip_slot": clip_slot,
             "notes_mode": notes_mode,
             "preserve_track_name": preserve_track_name,
+            "import_length": import_length,
+            "import_groove": import_groove,
         },
         action=_run,
     )

--- a/src/ableton_cli/commands/clip.py
+++ b/src/ableton_cli/commands/clip.py
@@ -11,6 +11,7 @@ from ._validation import (
     require_non_empty_string,
     require_non_negative,
     require_positive_float,
+    resolve_uri_or_path_target,
     validate_clip_note_filters,
 )
 
@@ -406,6 +407,83 @@ def clip_notes_replace(
             "start_time": start_time,
             "end_time": end_time,
             "pitch": pitch,
+        },
+        action=_run,
+    )
+
+
+@notes_app.command("import-browser")
+def clip_notes_import_browser(
+    ctx: typer.Context,
+    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    clip: Annotated[int, typer.Argument(help="Destination clip slot index (0-based)")],
+    target: Annotated[str, typer.Argument(help="Browser target (URI or path to .alc)")],
+    mode: Annotated[
+        str,
+        typer.Option("--mode", help="Note import mode: replace|append"),
+    ] = "replace",
+    import_length: Annotated[
+        bool,
+        typer.Option(
+            "--import-length/--no-import-length",
+            help="Copy source clip length into the destination clip",
+        ),
+    ] = False,
+    import_groove: Annotated[
+        bool,
+        typer.Option(
+            "--import-groove/--no-import-groove",
+            help="Copy source clip groove settings into the destination clip",
+        ),
+    ] = False,
+) -> None:
+    def _run() -> dict[str, object]:
+        require_non_negative(
+            "track",
+            track,
+            hint="Use a valid track index from 'ableton-cli tracks list'.",
+        )
+        require_non_negative(
+            "clip",
+            clip,
+            hint="Use a valid destination clip slot index.",
+        )
+        valid_mode = require_non_empty_string(
+            "mode",
+            mode,
+            hint="Use --mode replace or append.",
+        ).lower()
+        if valid_mode not in {"replace", "append"}:
+            raise invalid_argument(
+                message=f"mode must be one of replace/append, got {mode}",
+                hint="Use --mode replace or append.",
+            )
+        valid_uri, valid_path = resolve_uri_or_path_target(
+            target=target,
+            hint="Use a browser path or URI for a .alc MIDI clip item.",
+        )
+        return get_client(ctx).load_instrument_or_effect(
+            track=track,
+            uri=valid_uri,
+            path=valid_path,
+            target_track_mode="existing",
+            clip_slot=clip,
+            notes_mode=valid_mode,
+            preserve_track_name=False,
+            import_length=import_length,
+            import_groove=import_groove,
+        )
+
+    execute_command(
+        ctx,
+        command="clip notes import-browser",
+        args={
+            "track": track,
+            "clip": clip,
+            "target": target,
+            "mode": mode,
+            "import_length": import_length,
+            "import_groove": import_groove,
         },
         action=_run,
     )

--- a/tests/test_ableton_client.py
+++ b/tests/test_ableton_client.py
@@ -294,6 +294,29 @@ def test_client_sends_request_timeout_meta(monkeypatch) -> None:
             },
         ),
         (
+            lambda client: client.load_instrument_or_effect(
+                track=1,
+                uri=None,
+                path="sounds/Bass Loop.alc",
+                target_track_mode="existing",
+                clip_slot=3,
+                notes_mode="append",
+                import_length=True,
+                import_groove=True,
+            ),
+            "load_instrument_or_effect",
+            {
+                "track": 1,
+                "path": "sounds/Bass Loop.alc",
+                "target_track_mode": "existing",
+                "clip_slot": 3,
+                "preserve_track_name": False,
+                "notes_mode": "append",
+                "import_length": True,
+                "import_groove": True,
+            },
+        ),
+        (
             lambda client: client.clip_notes_quantize(
                 track=0,
                 clip=1,

--- a/tests/test_cli_new_commands.py
+++ b/tests/test_cli_new_commands.py
@@ -305,6 +305,8 @@ class _ClientStub:
         clip_slot: int | None = None,
         preserve_track_name: bool = False,
         notes_mode: str | None = None,
+        import_length: bool = False,
+        import_groove: bool = False,
     ):
         return {
             "track": track,
@@ -314,6 +316,8 @@ class _ClientStub:
             "clip_slot": clip_slot,
             "preserve_track_name": preserve_track_name,
             "notes_mode": notes_mode,
+            "import_length": import_length,
+            "import_groove": import_groove,
             "loaded": True,
         }
 
@@ -1198,6 +1202,79 @@ def test_browser_load_supports_notes_mode(runner, cli_app, monkeypatch) -> None:
     assert payload["ok"] is True
     assert payload["result"]["notes_mode"] == "append"
     assert payload["result"]["clip_slot"] == 2
+
+
+def test_browser_load_supports_length_and_groove_import_flags(runner, cli_app, monkeypatch) -> None:
+    from ableton_cli.commands import browser
+
+    monkeypatch.setattr(browser, "get_client", lambda ctx: _ClientStub())
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "1",
+            "sounds/Bass Loop.alc",
+            "--target-track-mode",
+            "existing",
+            "--clip-slot",
+            "2",
+            "--notes-mode",
+            "replace",
+            "--import-length",
+            "--import-groove",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["result"]["notes_mode"] == "replace"
+    assert payload["result"]["import_length"] is True
+    assert payload["result"]["import_groove"] is True
+
+
+def test_clip_notes_import_browser_supports_length_and_groove_flags(
+    runner,
+    cli_app,
+    monkeypatch,
+) -> None:
+    from ableton_cli.commands import clip
+
+    monkeypatch.setattr(clip, "get_client", lambda ctx: _ClientStub())
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "clip",
+            "notes",
+            "import-browser",
+            "1",
+            "3",
+            "packs/LoFi HipHop by Comakid/MIDI Clips/Drums/Fuji Drumkit groove 01 80 bpm.alc",
+            "--mode",
+            "append",
+            "--import-length",
+            "--import-groove",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["result"]["track"] == 1
+    assert payload["result"]["clip_slot"] == 3
+    assert payload["result"]["target_track_mode"] == "existing"
+    assert payload["result"]["notes_mode"] == "append"
+    assert payload["result"]["import_length"] is True
+    assert payload["result"]["import_groove"] is True
+    assert payload["result"]["path"].endswith(".alc")
+    assert payload["result"]["uri"] is None
 
 
 def test_browser_load_drum_kit_supports_kit_uri_or_path(runner, cli_app, monkeypatch) -> None:

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -404,6 +404,29 @@ def test_browser_load_rejects_invalid_notes_mode(runner, cli_app) -> None:
     assert payload["error"]["code"] == "INVALID_ARGUMENT"
 
 
+def test_browser_load_rejects_import_flags_without_notes_mode(runner, cli_app) -> None:
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "browser",
+            "load",
+            "0",
+            "sounds/Bass Loop.alc",
+            "--target-track-mode",
+            "existing",
+            "--clip-slot",
+            "1",
+            "--import-length",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "INVALID_ARGUMENT"
+
+
 def test_browser_load_drum_kit_requires_exactly_one_kit_selector(runner, cli_app) -> None:
     none_selected = runner.invoke(
         cli_app,
@@ -435,6 +458,28 @@ def test_clip_duplicate_rejects_invalid_to_list(runner, cli_app) -> None:
     result = runner.invoke(
         cli_app,
         ["--output", "json", "clip", "duplicate", "0", "1", "--to", "1,2"],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "INVALID_ARGUMENT"
+
+
+def test_clip_notes_import_browser_rejects_invalid_mode(runner, cli_app) -> None:
+    result = runner.invoke(
+        cli_app,
+        [
+            "--output",
+            "json",
+            "clip",
+            "notes",
+            "import-browser",
+            "0",
+            "1",
+            "sounds/Bass Loop.alc",
+            "--mode",
+            "merge",
+        ],
     )
 
     assert result.exit_code == 2

--- a/tests/test_live_backend.py
+++ b/tests/test_live_backend.py
@@ -1081,6 +1081,86 @@ def test_live_backend_load_notes_mode_does_not_require_selected_scene_none() -> 
     assert sorted(note["pitch"] for note in notes["notes"]) == [60]
 
 
+def test_live_backend_load_existing_mode_notes_mode_imports_length_and_groove() -> None:
+    surface = _SurfaceStub()
+    target_slot = surface.song().tracks[0].clip_slots[1]
+    target_slot.create_clip(length=2.0)
+    assert target_slot.clip is not None
+    target_slot.clip.set_notes(((72, 0.25, 0.5, 90, False),))
+    target_slot.clip.groove = "groove:old"
+    target_slot.clip.groove_amount = 0.1
+
+    browser = surface.application().browser
+    original_load_item = browser.load_item
+
+    def _load_item_force_new_track(item: _BrowserItem) -> None:
+        uri = str(getattr(item, "uri", ""))
+        if uri != "clip:bass-loop-alc":
+            original_load_item(item)
+            return
+        new_track = _Track(name="Imported Clip", has_audio_input=False, has_midi_input=True)
+        source_slot = new_track.clip_slots[0]
+        source_slot.create_clip(length=8.0)
+        assert source_slot.clip is not None
+        source_slot.clip.set_notes(((60, 0.0, 0.5, 100, False),))
+        source_slot.clip.groove = "groove:hip-hop-boom-bap-16ths-90"
+        source_slot.clip.groove_amount = 0.7
+        source_slot.clip._ableton_cli_groove_uri = "groove:hip-hop-boom-bap-16ths-90"  # noqa: SLF001
+        source_slot.clip._ableton_cli_groove_path = (  # noqa: SLF001
+            "grooves/Hip Hop Boom Bap 16ths 90 bpm.agr"
+        )
+        source_slot.clip._ableton_cli_groove_name = "Hip Hop Boom Bap 16ths 90 bpm.agr"  # noqa: SLF001
+        surface.song().tracks.append(new_track)
+
+    browser.load_item = _load_item_force_new_track  # type: ignore[method-assign]
+
+    backend = LiveBackend(surface)
+    loaded = backend.load_instrument_or_effect(
+        0,
+        uri=None,
+        path="sounds/Bass Loop.alc",
+        target_track_mode="existing",
+        clip_slot=1,
+        preserve_track_name=True,
+        notes_mode="replace",
+        import_length=True,
+        import_groove=True,
+    )
+
+    assert loaded["loaded"] is True
+    assert loaded["track_count_delta"] == 0
+    assert loaded["notes_imported"] == 1
+    assert loaded["length_imported"] is True
+    assert loaded["groove_imported"] is True
+
+    destination_slot = surface.song().tracks[0].clip_slots[1]
+    assert destination_slot.has_clip is True
+    destination_clip = destination_slot.clip
+    assert destination_clip is not None
+    assert destination_clip.length == 8.0
+    groove = backend.clip_groove_get(0, 1)
+    assert groove["groove_uri"] == "groove:hip-hop-boom-bap-16ths-90"
+    assert groove["groove_path"] == "grooves/Hip Hop Boom Bap 16ths 90 bpm.agr"
+    assert groove["groove_name"] == "Hip Hop Boom Bap 16ths 90 bpm.agr"
+
+
+def test_live_backend_load_rejects_import_length_without_notes_mode() -> None:
+    backend = LiveBackend(_SurfaceStub())
+
+    with pytest.raises(CommandError) as exc_info:
+        backend.load_instrument_or_effect(
+            0,
+            uri=None,
+            path="sounds/Bass Loop.alc",
+            target_track_mode="existing",
+            clip_slot=1,
+            preserve_track_name=False,
+            import_length=True,
+        )
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
+
+
 def test_live_backend_load_notes_mode_requires_existing_clip() -> None:
     backend = LiveBackend(_SurfaceStub())
 

--- a/tests/test_remote_command_backend.py
+++ b/tests/test_remote_command_backend.py
@@ -306,6 +306,8 @@ class _BackendStub:
         clip_slot: int | None,
         preserve_track_name: bool,
         notes_mode: str | None,
+        import_length: bool,
+        import_groove: bool,
     ):
         return {
             "track": track,
@@ -315,6 +317,8 @@ class _BackendStub:
             "clip_slot": clip_slot,
             "preserve_track_name": preserve_track_name,
             "notes_mode": notes_mode,
+            "import_length": import_length,
+            "import_groove": import_groove,
             "loaded": True,
         }
 
@@ -875,6 +879,8 @@ def test_dispatch_calls_backend_for_browser_load_with_path() -> None:
         "clip_slot": None,
         "preserve_track_name": False,
         "notes_mode": None,
+        "import_length": False,
+        "import_groove": False,
         "loaded": True,
     }
 
@@ -900,6 +906,8 @@ def test_dispatch_calls_backend_for_browser_load_with_existing_mode_and_clip_slo
         "clip_slot": 3,
         "preserve_track_name": True,
         "notes_mode": None,
+        "import_length": False,
+        "import_groove": False,
         "loaded": True,
     }
 
@@ -925,6 +933,37 @@ def test_dispatch_calls_backend_for_browser_load_with_notes_mode() -> None:
         "clip_slot": 2,
         "preserve_track_name": False,
         "notes_mode": "append",
+        "import_length": False,
+        "import_groove": False,
+        "loaded": True,
+    }
+
+
+def test_dispatch_calls_backend_for_browser_load_with_notes_import_flags() -> None:
+    backend = _BackendStub()
+    result = dispatch_command(
+        backend,
+        "load_instrument_or_effect",
+        {
+            "track": 1,
+            "path": "sounds/Bass Loop.alc",
+            "target_track_mode": "existing",
+            "clip_slot": 2,
+            "notes_mode": "replace",
+            "import_length": True,
+            "import_groove": True,
+        },
+    )
+    assert result == {
+        "track": 1,
+        "uri": None,
+        "path": "sounds/Bass Loop.alc",
+        "target_track_mode": "existing",
+        "clip_slot": 2,
+        "preserve_track_name": False,
+        "notes_mode": "replace",
+        "import_length": True,
+        "import_groove": True,
         "loaded": True,
     }
 
@@ -1508,6 +1547,25 @@ def test_dispatch_rejects_browser_load_with_invalid_notes_mode() -> None:
                 "target_track_mode": "existing",
                 "clip_slot": 1,
                 "notes_mode": "merge",
+            },
+        )
+
+    assert exc_info.value.code == "INVALID_ARGUMENT"
+
+
+def test_dispatch_rejects_browser_load_with_non_boolean_import_flags() -> None:
+    backend = _BackendStub()
+    with pytest.raises(CommandError) as exc_info:
+        dispatch_command(
+            backend,
+            "load_instrument_or_effect",
+            {
+                "track": 0,
+                "path": "sounds/Bass Loop.alc",
+                "target_track_mode": "existing",
+                "clip_slot": 1,
+                "notes_mode": "replace",
+                "import_length": "true",
             },
         )
 


### PR DESCRIPTION
## 概要
Fixes #20

Pack MIDI Clip (`.alc`) を既存クリップへノート展開するための専用導線を追加しました。

- 新コマンド: `clip notes import-browser <track> <clip> <target>`
- 既存 `browser load` の notes 取込にも、長さ/グルーヴ取込フラグを追加

## 何が問題だったか
- 既存 clip への Pack MIDI ノート展開は `browser load --notes-mode ...` を直接組み合わせる必要があり、意図が分かりにくく、ワークフローとして使いにくい状態でした。
- `.alc` 側の長さ・グルーヴ取込可否を明示的に指定できませんでした。

## 対応内容
### 1) CLI 追加
- `clip notes import-browser` を追加。
  - `--mode replace|append`
  - `--import-length/--no-import-length`
  - `--import-groove/--no-import-groove`
- URI/path 解決を共通バリデーション化して、`browser` と `clip` で再利用しました。

### 2) Browser load 拡張
- `browser load` にも以下を追加。
  - `--import-length/--no-import-length`
  - `--import-groove/--no-import-groove`
- `--notes-mode` なしで import フラグだけ渡された場合は明示的に `INVALID_ARGUMENT` を返します。

### 3) backend 拡張
- `load_instrument_or_effect` に `import_length/import_groove` を追加。
- `notes_mode` 実行時に、ノート取込に加えて以下を選択的に反映。
  - clip length
  - groove / groove amount / groove metadata

### 4) ドキュメント
- README に `clip notes import-browser` と拡張 `browser load` の例を追記。

## ユーザー影響
- Pack MIDI clip を既存 clip へ展開する操作が 1 コマンドで明確になりました。
- 新規トラックを作らずに `replace/append` でき、長さ・グルーヴ取り込みも必要に応じて選択できます。

## テスト
- `uv run pytest tests/test_cli_new_commands.py -q`
- `uv run pytest tests/test_cli_validation.py -q`
- `uv run pytest tests/test_remote_command_backend.py -q`
- `uv run pytest tests/test_live_backend.py -q`
- `uv run pytest tests/test_ableton_client.py -q`
