### PR TITLE
[codex] #20 CI失敗: skill doc のコマンド記載漏れを修正

### DIFF
--- a/skills/ableton-cli/SKILL.md
+++ b/skills/ableton-cli/SKILL.md
@@ -99,6 +99,7 @@ uv run ableton-cli clip notes add 0 0 --notes-file ./notes.json
 uv run ableton-cli clip notes get 0 0 --start-time 0.0 --end-time 4.0 --pitch 60
 uv run ableton-cli clip notes clear 0 0 --start-time 0.0 --end-time 1.0
 uv run ableton-cli clip notes replace 0 0 --notes-json '[{"pitch":65,"start_time":0.25,"duration":0.5,"velocity":100,"mute":false}]' --start-time 0.0 --end-time 1.0
+uv run ableton-cli clip notes import-browser 0 1 sounds/Bass\ Loop.alc --mode replace --import-length --import-groove
 uv run ableton-cli clip notes quantize 0 0 --grid 1/16 --strength 0.8 --start-time 0.0 --end-time 4.0
 uv run ableton-cli clip notes humanize 0 0 --timing 0.05 --velocity 5
 uv run ableton-cli clip notes velocity-scale 0 0 --scale 1.1 --offset -3


### PR DESCRIPTION
## 概要
#20 のCI失敗を修正します。

## 原因
`tests/test_skill_docs.py::test_skill_doc_covers_all_leaf_cli_commands` が、
`skills/ableton-cli/SKILL.md` に新規コマンド `clip notes import-browser` の記載がないことで失敗していました。

## 対応
- `skills/ableton-cli/SKILL.md` の Clip セクションに以下を追加
  - `uv run ableton-cli clip notes import-browser ...`

## 確認
- `uv run pytest tests/test_skill_docs.py -q`
