### PR TITLE
[codex] reduce command validation duplication

### DIFF
--- a/src/ableton_cli/commands/_validation.py
+++ b/src/ableton_cli/commands/_validation.py
@@ -7,6 +7,8 @@ from typing import Any
 from ..errors import AppError, ExitCode
 
 NOTE_KEYS = {"pitch", "start_time", "duration", "velocity", "mute"}
+TRACK_INDEX_HINT = "Use a valid track index from 'ableton-cli tracks list'."
+DEVICE_INDEX_HINT = "Use a valid device index from 'ableton-cli track info'."
 
 
 def invalid_argument(message: str, hint: str) -> AppError:
@@ -24,6 +26,18 @@ def require_non_negative(name: str, value: int, *, hint: str) -> int:
     return value
 
 
+def require_track_index(value: int, *, hint: str = TRACK_INDEX_HINT) -> int:
+    return require_non_negative("track", value, hint=hint)
+
+
+def require_device_index(value: int, *, hint: str = DEVICE_INDEX_HINT) -> int:
+    return require_non_negative("device", value, hint=hint)
+
+
+def require_parameter_index(value: int, *, hint: str) -> int:
+    return require_non_negative("parameter", value, hint=hint)
+
+
 def require_minus_one_or_non_negative(name: str, value: int, *, hint: str) -> int:
     if value < -1:
         raise invalid_argument(message=f"{name} must be >= -1, got {value}", hint=hint)
@@ -39,6 +53,22 @@ def require_positive_float(name: str, value: float, *, hint: str) -> float:
 def require_non_negative_float(name: str, value: float, *, hint: str) -> float:
     if value < 0:
         raise invalid_argument(message=f"{name} must be >= 0, got {value}", hint=hint)
+    return value
+
+
+def require_float_in_range(
+    name: str,
+    value: float,
+    *,
+    minimum: float,
+    maximum: float,
+    hint: str,
+) -> float:
+    if value < minimum or value > maximum:
+        raise invalid_argument(
+            message=f"{name} must be between {minimum} and {maximum}, got {value}",
+            hint=hint,
+        )
     return value
 
 

--- a/src/ableton_cli/commands/effect.py
+++ b/src/ableton_cli/commands/effect.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Annotated
 
 import typer
 
 from ..runtime import execute_command, get_client
-from ._validation import invalid_argument, require_non_empty_string, require_non_negative
+from ._validation import (
+    invalid_argument,
+    require_device_index,
+    require_non_empty_string,
+    require_parameter_index,
+    require_track_index,
+)
 
 _SUPPORTED_EFFECT_TYPES = (
     "eq8",
@@ -15,6 +22,10 @@ _SUPPORTED_EFFECT_TYPES = (
     "reverb",
     "utility",
 )
+
+TrackArgument = Annotated[int, typer.Argument(help="Track index (0-based)")]
+DeviceArgument = Annotated[int, typer.Argument(help="Device index (0-based)")]
+ParameterArgument = Annotated[int, typer.Argument(help="Parameter index (0-based)")]
 
 effect_app = typer.Typer(help="Effect control commands", no_args_is_help=True)
 parameters_app = typer.Typer(help="Effect parameter listing commands", no_args_is_help=True)
@@ -30,6 +41,46 @@ def _normalize_effect_type(value: str) -> str:
             hint="Use a supported effect type.",
         )
     return normalized
+
+
+def _require_optional_track_index(track: int | None) -> int | None:
+    if track is None:
+        return None
+    return require_track_index(track)
+
+
+def _require_track_and_device_index(track: int, device: int) -> tuple[int, int]:
+    return (
+        require_track_index(track),
+        require_device_index(device),
+    )
+
+
+def _require_effect_parameter_index(parameter: int) -> int:
+    return require_parameter_index(
+        parameter,
+        hint="Use a valid parameter index from 'ableton-cli effect parameters list'.",
+    )
+
+
+def _execute_track_device_command(
+    ctx: typer.Context,
+    *,
+    command: str,
+    track: int,
+    device: int,
+    action: Callable[[int, int], dict[str, object]],
+) -> None:
+    def _run() -> dict[str, object]:
+        valid_track, valid_device = _require_track_and_device_index(track, device)
+        return action(valid_track, valid_device)
+
+    execute_command(
+        ctx,
+        command=command,
+        args={"track": track, "device": device},
+        action=_run,
+    )
 
 
 @effect_app.command("find")
@@ -48,14 +99,9 @@ def effect_find(
     ] = None,
 ) -> None:
     def _run() -> dict[str, object]:
-        if track is not None:
-            require_non_negative(
-                "track",
-                track,
-                hint="Use a valid track index from 'ableton-cli tracks list'.",
-            )
+        valid_track = _require_optional_track_index(track)
         valid_type = _normalize_effect_type(effect_type) if effect_type is not None else None
-        return get_client(ctx).find_effect_devices(track=track, effect_type=valid_type)
+        return get_client(ctx).find_effect_devices(track=valid_track, effect_type=valid_type)
 
     execute_command(
         ctx,
@@ -68,58 +114,36 @@ def effect_find(
 @parameters_app.command("list")
 def effect_parameters_list(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+    track: TrackArgument,
+    device: DeviceArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        require_non_negative(
-            "device",
-            device,
-            hint="Use a valid device index from 'ableton-cli track info'.",
-        )
-        return get_client(ctx).list_effect_parameters(track=track, device=device)
-
-    execute_command(
+    _execute_track_device_command(
         ctx,
         command="effect parameters list",
-        args={"track": track, "device": device},
-        action=_run,
+        track=track,
+        device=device,
+        action=lambda valid_track, valid_device: get_client(ctx).list_effect_parameters(
+            track=valid_track,
+            device=valid_device,
+        ),
     )
 
 
 @parameter_app.command("set")
 def effect_parameter_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    device: Annotated[int, typer.Argument(help="Device index (0-based)")],
-    parameter: Annotated[int, typer.Argument(help="Parameter index (0-based)")],
+    track: TrackArgument,
+    device: DeviceArgument,
+    parameter: ParameterArgument,
     value: Annotated[float, typer.Argument(help="Target parameter value")],
 ) -> None:
     def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        require_non_negative(
-            "device",
-            device,
-            hint="Use a valid device index from 'ableton-cli track info'.",
-        )
-        require_non_negative(
-            "parameter",
-            parameter,
-            hint="Use a valid parameter index from 'ableton-cli effect parameters list'.",
-        )
+        valid_track, valid_device = _require_track_and_device_index(track, device)
+        valid_parameter = _require_effect_parameter_index(parameter)
         return get_client(ctx).set_effect_parameter_safe(
-            track=track,
-            device=device,
-            parameter=parameter,
+            track=valid_track,
+            device=valid_device,
+            parameter=valid_parameter,
             value=value,
         )
 
@@ -134,27 +158,18 @@ def effect_parameter_set(
 @effect_app.command("observe")
 def effect_observe(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+    track: TrackArgument,
+    device: DeviceArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        require_non_negative(
-            "device",
-            device,
-            hint="Use a valid device index from 'ableton-cli track info'.",
-        )
-        return get_client(ctx).observe_effect_parameters(track=track, device=device)
-
-    execute_command(
+    _execute_track_device_command(
         ctx,
         command="effect observe",
-        args={"track": track, "device": device},
-        action=_run,
+        track=track,
+        device=device,
+        action=lambda valid_track, valid_device: get_client(ctx).observe_effect_parameters(
+            track=valid_track,
+            device=valid_device,
+        ),
     )
 
 
@@ -176,22 +191,13 @@ def _build_standard_effect_app(effect_type: str, cli_name: str) -> typer.Typer:
     @standard_app.command("set")
     def standard_set(
         ctx: typer.Context,
-        track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-        device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+        track: TrackArgument,
+        device: DeviceArgument,
         key: Annotated[str, typer.Argument(help="Stable effect key")],
         value: Annotated[float, typer.Argument(help="Target parameter value")],
     ) -> None:
         def _run() -> dict[str, object]:
-            require_non_negative(
-                "track",
-                track,
-                hint="Use a valid track index from 'ableton-cli tracks list'.",
-            )
-            require_non_negative(
-                "device",
-                device,
-                hint="Use a valid device index from 'ableton-cli track info'.",
-            )
+            valid_track, valid_device = _require_track_and_device_index(track, device)
             valid_key = require_non_empty_string(
                 "key",
                 key,
@@ -199,8 +205,8 @@ def _build_standard_effect_app(effect_type: str, cli_name: str) -> typer.Typer:
             )
             return get_client(ctx).set_standard_effect_parameter_safe(
                 effect_type=effect_type,
-                track=track,
-                device=device,
+                track=valid_track,
+                device=valid_device,
                 key=valid_key,
                 value=value,
             )
@@ -215,31 +221,19 @@ def _build_standard_effect_app(effect_type: str, cli_name: str) -> typer.Typer:
     @standard_app.command("observe")
     def standard_observe(
         ctx: typer.Context,
-        track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-        device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+        track: TrackArgument,
+        device: DeviceArgument,
     ) -> None:
-        def _run() -> dict[str, object]:
-            require_non_negative(
-                "track",
-                track,
-                hint="Use a valid track index from 'ableton-cli tracks list'.",
-            )
-            require_non_negative(
-                "device",
-                device,
-                hint="Use a valid device index from 'ableton-cli track info'.",
-            )
-            return get_client(ctx).observe_standard_effect_state(
-                effect_type=effect_type,
-                track=track,
-                device=device,
-            )
-
-        execute_command(
+        _execute_track_device_command(
             ctx,
             command=f"effect {cli_name} observe",
-            args={"track": track, "device": device},
-            action=_run,
+            track=track,
+            device=device,
+            action=lambda valid_track, valid_device: get_client(ctx).observe_standard_effect_state(
+                effect_type=effect_type,
+                track=valid_track,
+                device=valid_device,
+            ),
         )
 
     return standard_app

--- a/src/ableton_cli/commands/synth.py
+++ b/src/ableton_cli/commands/synth.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Annotated
 
 import typer
 
 from ..runtime import execute_command, get_client
-from ._validation import invalid_argument, require_non_empty_string, require_non_negative
+from ._validation import (
+    invalid_argument,
+    require_device_index,
+    require_non_empty_string,
+    require_parameter_index,
+    require_track_index,
+)
 
 _SUPPORTED_SYNTH_TYPES = ("wavetable", "drift", "meld")
+
+TrackArgument = Annotated[int, typer.Argument(help="Track index (0-based)")]
+DeviceArgument = Annotated[int, typer.Argument(help="Device index (0-based)")]
+ParameterArgument = Annotated[int, typer.Argument(help="Parameter index (0-based)")]
 
 synth_app = typer.Typer(help="Synth control commands", no_args_is_help=True)
 parameters_app = typer.Typer(help="Synth parameter listing commands", no_args_is_help=True)
@@ -25,6 +36,46 @@ def _normalize_synth_type(value: str) -> str:
     return normalized
 
 
+def _require_optional_track_index(track: int | None) -> int | None:
+    if track is None:
+        return None
+    return require_track_index(track)
+
+
+def _require_track_and_device_index(track: int, device: int) -> tuple[int, int]:
+    return (
+        require_track_index(track),
+        require_device_index(device),
+    )
+
+
+def _require_synth_parameter_index(parameter: int) -> int:
+    return require_parameter_index(
+        parameter,
+        hint="Use a valid parameter index from 'ableton-cli synth parameters list'.",
+    )
+
+
+def _execute_track_device_command(
+    ctx: typer.Context,
+    *,
+    command: str,
+    track: int,
+    device: int,
+    action: Callable[[int, int], dict[str, object]],
+) -> None:
+    def _run() -> dict[str, object]:
+        valid_track, valid_device = _require_track_and_device_index(track, device)
+        return action(valid_track, valid_device)
+
+    execute_command(
+        ctx,
+        command=command,
+        args={"track": track, "device": device},
+        action=_run,
+    )
+
+
 @synth_app.command("find")
 def synth_find(
     ctx: typer.Context,
@@ -38,14 +89,9 @@ def synth_find(
     ] = None,
 ) -> None:
     def _run() -> dict[str, object]:
-        if track is not None:
-            require_non_negative(
-                "track",
-                track,
-                hint="Use a valid track index from 'ableton-cli tracks list'.",
-            )
+        valid_track = _require_optional_track_index(track)
         valid_type = _normalize_synth_type(synth_type) if synth_type is not None else None
-        return get_client(ctx).find_synth_devices(track=track, synth_type=valid_type)
+        return get_client(ctx).find_synth_devices(track=valid_track, synth_type=valid_type)
 
     execute_command(
         ctx,
@@ -58,58 +104,36 @@ def synth_find(
 @parameters_app.command("list")
 def synth_parameters_list(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+    track: TrackArgument,
+    device: DeviceArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        require_non_negative(
-            "device",
-            device,
-            hint="Use a valid device index from 'ableton-cli track info'.",
-        )
-        return get_client(ctx).list_synth_parameters(track=track, device=device)
-
-    execute_command(
+    _execute_track_device_command(
         ctx,
         command="synth parameters list",
-        args={"track": track, "device": device},
-        action=_run,
+        track=track,
+        device=device,
+        action=lambda valid_track, valid_device: get_client(ctx).list_synth_parameters(
+            track=valid_track,
+            device=valid_device,
+        ),
     )
 
 
 @parameter_app.command("set")
 def synth_parameter_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    device: Annotated[int, typer.Argument(help="Device index (0-based)")],
-    parameter: Annotated[int, typer.Argument(help="Parameter index (0-based)")],
+    track: TrackArgument,
+    device: DeviceArgument,
+    parameter: ParameterArgument,
     value: Annotated[float, typer.Argument(help="Target parameter value")],
 ) -> None:
     def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        require_non_negative(
-            "device",
-            device,
-            hint="Use a valid device index from 'ableton-cli track info'.",
-        )
-        require_non_negative(
-            "parameter",
-            parameter,
-            hint="Use a valid parameter index from 'ableton-cli synth parameters list'.",
-        )
+        valid_track, valid_device = _require_track_and_device_index(track, device)
+        valid_parameter = _require_synth_parameter_index(parameter)
         return get_client(ctx).set_synth_parameter_safe(
-            track=track,
-            device=device,
-            parameter=parameter,
+            track=valid_track,
+            device=valid_device,
+            parameter=valid_parameter,
             value=value,
         )
 
@@ -124,27 +148,18 @@ def synth_parameter_set(
 @synth_app.command("observe")
 def synth_observe(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+    track: TrackArgument,
+    device: DeviceArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        require_non_negative(
-            "device",
-            device,
-            hint="Use a valid device index from 'ableton-cli track info'.",
-        )
-        return get_client(ctx).observe_synth_parameters(track=track, device=device)
-
-    execute_command(
+    _execute_track_device_command(
         ctx,
         command="synth observe",
-        args={"track": track, "device": device},
-        action=_run,
+        track=track,
+        device=device,
+        action=lambda valid_track, valid_device: get_client(ctx).observe_synth_parameters(
+            track=valid_track,
+            device=valid_device,
+        ),
     )
 
 
@@ -166,22 +181,13 @@ def _build_standard_synth_app(synth_type: str) -> typer.Typer:
     @standard_app.command("set")
     def standard_set(
         ctx: typer.Context,
-        track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-        device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+        track: TrackArgument,
+        device: DeviceArgument,
         key: Annotated[str, typer.Argument(help="Stable synth key")],
         value: Annotated[float, typer.Argument(help="Target parameter value")],
     ) -> None:
         def _run() -> dict[str, object]:
-            require_non_negative(
-                "track",
-                track,
-                hint="Use a valid track index from 'ableton-cli tracks list'.",
-            )
-            require_non_negative(
-                "device",
-                device,
-                hint="Use a valid device index from 'ableton-cli track info'.",
-            )
+            valid_track, valid_device = _require_track_and_device_index(track, device)
             valid_key = require_non_empty_string(
                 "key",
                 key,
@@ -189,8 +195,8 @@ def _build_standard_synth_app(synth_type: str) -> typer.Typer:
             )
             return get_client(ctx).set_standard_synth_parameter_safe(
                 synth_type=synth_type,
-                track=track,
-                device=device,
+                track=valid_track,
+                device=valid_device,
                 key=valid_key,
                 value=value,
             )
@@ -205,31 +211,19 @@ def _build_standard_synth_app(synth_type: str) -> typer.Typer:
     @standard_app.command("observe")
     def standard_observe(
         ctx: typer.Context,
-        track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-        device: Annotated[int, typer.Argument(help="Device index (0-based)")],
+        track: TrackArgument,
+        device: DeviceArgument,
     ) -> None:
-        def _run() -> dict[str, object]:
-            require_non_negative(
-                "track",
-                track,
-                hint="Use a valid track index from 'ableton-cli tracks list'.",
-            )
-            require_non_negative(
-                "device",
-                device,
-                hint="Use a valid device index from 'ableton-cli track info'.",
-            )
-            return get_client(ctx).observe_standard_synth_state(
-                synth_type=synth_type,
-                track=track,
-                device=device,
-            )
-
-        execute_command(
+        _execute_track_device_command(
             ctx,
             command=f"synth {synth_type} observe",
-            args={"track": track, "device": device},
-            action=_run,
+            track=track,
+            device=device,
+            action=lambda valid_track, valid_device: get_client(ctx).observe_standard_synth_state(
+                synth_type=synth_type,
+                track=valid_track,
+                device=valid_device,
+            ),
         )
 
     return standard_app

--- a/src/ableton_cli/commands/track.py
+++ b/src/ableton_cli/commands/track.py
@@ -1,11 +1,89 @@
 from __future__ import annotations
 
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, TypeVar
 
 import typer
 
 from ..runtime import execute_command, get_client
-from ._validation import invalid_argument, require_non_empty_string, require_non_negative
+from ._validation import require_float_in_range, require_non_empty_string, require_track_index
+
+TValue = TypeVar("TValue")
+
+TrackArgument = Annotated[int, typer.Argument(help="Track index (0-based)")]
+VolumeValueArgument = Annotated[float, typer.Argument(help="Volume value in [0.0, 1.0]")]
+PanningValueArgument = Annotated[float, typer.Argument(help="Panning value in [-1.0, 1.0]")]
+
+
+def _execute_track_get(
+    ctx: typer.Context,
+    *,
+    command: str,
+    track: int,
+    action: Callable[[int], dict[str, object]],
+) -> None:
+    def _run() -> dict[str, object]:
+        valid_track = require_track_index(track)
+        return action(valid_track)
+
+    execute_command(
+        ctx,
+        command=command,
+        args={"track": track},
+        action=_run,
+    )
+
+
+def _execute_track_set(
+    ctx: typer.Context,
+    *,
+    command: str,
+    track: int,
+    value: TValue,
+    action: Callable[[int, TValue], dict[str, object]],
+    value_name: str = "value",
+    validator: Callable[[TValue], TValue] | None = None,
+) -> None:
+    def _run() -> dict[str, object]:
+        valid_track = require_track_index(track)
+        valid_value = validator(value) if validator is not None else value
+        return action(valid_track, valid_value)
+
+    execute_command(
+        ctx,
+        command=command,
+        args={"track": track, value_name: value},
+        action=_run,
+    )
+
+
+def _require_volume_value(value: float) -> float:
+    return require_float_in_range(
+        "value",
+        value,
+        minimum=0.0,
+        maximum=1.0,
+        hint="Use a normalized volume value such as 0.75.",
+    )
+
+
+def _require_panning_value(value: float) -> float:
+    return require_float_in_range(
+        "value",
+        value,
+        minimum=-1.0,
+        maximum=1.0,
+        hint="Use a normalized panning value such as -0.25.",
+    )
+
+
+def _require_track_name(value: str) -> str:
+    return require_non_empty_string(
+        "name",
+        value,
+        hint="Pass a non-empty track name.",
+    )
+
 
 track_app = typer.Typer(help="Single-track commands", no_args_is_help=True)
 volume_app = typer.Typer(help="Track volume commands", no_args_is_help=True)
@@ -19,273 +97,190 @@ panning_app = typer.Typer(help="Track panning commands", no_args_is_help=True)
 @track_app.command("info")
 def track_info(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).get_track_info(track)
-
-    execute_command(
+    _execute_track_get(
         ctx,
         command="track info",
-        args={"track": track},
-        action=_run,
+        track=track,
+        action=lambda valid_track: get_client(ctx).get_track_info(valid_track),
     )
 
 
 @volume_app.command("get")
 def volume_get(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
 ) -> None:
-    def _run() -> dict[str, float | int]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_volume_get(track)
-
-    execute_command(
+    _execute_track_get(
         ctx,
         command="track volume get",
-        args={"track": track},
-        action=_run,
+        track=track,
+        action=lambda valid_track: get_client(ctx).track_volume_get(valid_track),
     )
 
 
 @volume_app.command("set")
 def volume_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    value: Annotated[float, typer.Argument(help="Volume value in [0.0, 1.0]")],
+    track: TrackArgument,
+    value: VolumeValueArgument,
 ) -> None:
-    def _run() -> dict[str, float | int]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        if value < 0.0 or value > 1.0:
-            raise invalid_argument(
-                message=f"value must be between 0.0 and 1.0, got {value}",
-                hint="Use a normalized volume value such as 0.75.",
-            )
-        return get_client(ctx).track_volume_set(track, value)
-
-    execute_command(
+    _execute_track_set(
         ctx,
         command="track volume set",
-        args={"track": track, "value": value},
-        action=_run,
+        track=track,
+        value=value,
+        validator=_require_volume_value,
+        action=lambda valid_track, valid_value: get_client(ctx).track_volume_set(
+            valid_track,
+            valid_value,
+        ),
     )
 
 
 @name_app.command("set")
 def track_name_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
     name: Annotated[str, typer.Argument(help="New track name")],
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        valid_name = require_non_empty_string(
-            "name",
-            name,
-            hint="Pass a non-empty track name.",
-        )
-        return get_client(ctx).set_track_name(track, valid_name)
-
-    execute_command(
+    _execute_track_set(
         ctx,
         command="track name set",
-        args={"track": track, "name": name},
-        action=_run,
+        track=track,
+        value=name,
+        value_name="name",
+        validator=_require_track_name,
+        action=lambda valid_track, valid_name: get_client(ctx).set_track_name(
+            valid_track,
+            valid_name,
+        ),
     )
 
 
 @mute_app.command("get")
 def mute_get(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_mute_get(track)
-
-    execute_command(
+    _execute_track_get(
         ctx,
         command="track mute get",
-        args={"track": track},
-        action=_run,
+        track=track,
+        action=lambda valid_track: get_client(ctx).track_mute_get(valid_track),
     )
 
 
 @mute_app.command("set")
 def mute_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
     value: Annotated[bool, typer.Argument(help="Mute value: true|false")],
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_mute_set(track, value)
-
-    execute_command(
+    _execute_track_set(
         ctx,
         command="track mute set",
-        args={"track": track, "value": value},
-        action=_run,
+        track=track,
+        value=value,
+        action=lambda valid_track, valid_value: get_client(ctx).track_mute_set(
+            valid_track,
+            valid_value,
+        ),
     )
 
 
 @solo_app.command("get")
 def solo_get(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_solo_get(track)
-
-    execute_command(
+    _execute_track_get(
         ctx,
         command="track solo get",
-        args={"track": track},
-        action=_run,
+        track=track,
+        action=lambda valid_track: get_client(ctx).track_solo_get(valid_track),
     )
 
 
 @solo_app.command("set")
 def solo_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
     value: Annotated[bool, typer.Argument(help="Solo value: true|false")],
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_solo_set(track, value)
-
-    execute_command(
+    _execute_track_set(
         ctx,
         command="track solo set",
-        args={"track": track, "value": value},
-        action=_run,
+        track=track,
+        value=value,
+        action=lambda valid_track, valid_value: get_client(ctx).track_solo_set(
+            valid_track,
+            valid_value,
+        ),
     )
 
 
 @arm_app.command("get")
 def arm_get(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_arm_get(track)
-
-    execute_command(
+    _execute_track_get(
         ctx,
         command="track arm get",
-        args={"track": track},
-        action=_run,
+        track=track,
+        action=lambda valid_track: get_client(ctx).track_arm_get(valid_track),
     )
 
 
 @arm_app.command("set")
 def arm_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
     value: Annotated[bool, typer.Argument(help="Arm value: true|false")],
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_arm_set(track, value)
-
-    execute_command(
+    _execute_track_set(
         ctx,
         command="track arm set",
-        args={"track": track, "value": value},
-        action=_run,
+        track=track,
+        value=value,
+        action=lambda valid_track, valid_value: get_client(ctx).track_arm_set(
+            valid_track,
+            valid_value,
+        ),
     )
 
 
 @panning_app.command("get")
 def panning_get(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
+    track: TrackArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        return get_client(ctx).track_panning_get(track)
-
-    execute_command(
+    _execute_track_get(
         ctx,
         command="track panning get",
-        args={"track": track},
-        action=_run,
+        track=track,
+        action=lambda valid_track: get_client(ctx).track_panning_get(valid_track),
     )
 
 
 @panning_app.command("set")
 def panning_set(
     ctx: typer.Context,
-    track: Annotated[int, typer.Argument(help="Track index (0-based)")],
-    value: Annotated[float, typer.Argument(help="Panning value in [-1.0, 1.0]")],
+    track: TrackArgument,
+    value: PanningValueArgument,
 ) -> None:
-    def _run() -> dict[str, object]:
-        require_non_negative(
-            "track",
-            track,
-            hint="Use a valid track index from 'ableton-cli tracks list'.",
-        )
-        if value < -1.0 or value > 1.0:
-            raise invalid_argument(
-                message=f"value must be between -1.0 and 1.0, got {value}",
-                hint="Use a normalized panning value such as -0.25.",
-            )
-        return get_client(ctx).track_panning_set(track, value)
-
-    execute_command(
+    _execute_track_set(
         ctx,
         command="track panning set",
-        args={"track": track, "value": value},
-        action=_run,
+        track=track,
+        value=value,
+        validator=_require_panning_value,
+        action=lambda valid_track, valid_value: get_client(ctx).track_panning_set(
+            valid_track,
+            valid_value,
+        ),
     )
 
 

--- a/tests/commands/test_validation.py
+++ b/tests/commands/test_validation.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from ableton_cli.errors import AppError
+
+
+def _assert_invalid_argument(exc: pytest.ExceptionInfo[AppError]) -> None:
+    assert exc.value.error_code == "INVALID_ARGUMENT"
+
+
+def test_require_track_index_accepts_zero_or_positive_values() -> None:
+    from ableton_cli.commands._validation import require_track_index
+
+    assert require_track_index(0) == 0
+    assert require_track_index(3) == 3
+
+
+def test_require_track_index_rejects_negative_values() -> None:
+    from ableton_cli.commands._validation import require_track_index
+
+    with pytest.raises(AppError) as exc:
+        require_track_index(-1)
+
+    _assert_invalid_argument(exc)
+    assert exc.value.message == "track must be >= 0, got -1"
+    assert exc.value.hint == "Use a valid track index from 'ableton-cli tracks list'."
+
+
+def test_require_device_index_accepts_zero_or_positive_values() -> None:
+    from ableton_cli.commands._validation import require_device_index
+
+    assert require_device_index(0) == 0
+    assert require_device_index(5) == 5
+
+
+def test_require_device_index_rejects_negative_values() -> None:
+    from ableton_cli.commands._validation import require_device_index
+
+    with pytest.raises(AppError) as exc:
+        require_device_index(-1)
+
+    _assert_invalid_argument(exc)
+    assert exc.value.message == "device must be >= 0, got -1"
+    assert exc.value.hint == "Use a valid device index from 'ableton-cli track info'."
+
+
+def test_require_parameter_index_rejects_negative_values_with_custom_hint() -> None:
+    from ableton_cli.commands._validation import require_parameter_index
+
+    with pytest.raises(AppError) as exc:
+        require_parameter_index(
+            -1, hint="Use a valid parameter index from 'ableton-cli synth parameters list'."
+        )
+
+    _assert_invalid_argument(exc)
+    assert exc.value.message == "parameter must be >= 0, got -1"
+    assert exc.value.hint == "Use a valid parameter index from 'ableton-cli synth parameters list'."
+
+
+def test_require_float_in_range_accepts_boundary_values() -> None:
+    from ableton_cli.commands._validation import require_float_in_range
+
+    assert (
+        require_float_in_range(
+            "value",
+            0.0,
+            minimum=0.0,
+            maximum=1.0,
+            hint="Use a normalized value such as 0.75.",
+        )
+        == 0.0
+    )
+    assert (
+        require_float_in_range(
+            "value",
+            1.0,
+            minimum=0.0,
+            maximum=1.0,
+            hint="Use a normalized value such as 0.75.",
+        )
+        == 1.0
+    )
+
+
+def test_require_float_in_range_rejects_out_of_range_values() -> None:
+    from ableton_cli.commands._validation import require_float_in_range
+
+    with pytest.raises(AppError) as exc:
+        require_float_in_range(
+            "value",
+            1.2,
+            minimum=0.0,
+            maximum=1.0,
+            hint="Use a normalized value such as 0.75.",
+        )
+
+    _assert_invalid_argument(exc)
+    assert exc.value.message == "value must be between 0.0 and 1.0, got 1.2"
+    assert exc.value.hint == "Use a normalized value such as 0.75."


### PR DESCRIPTION
## 概要
track/synth/effect の各コマンドで、`track`・`device`・`parameter` の入力検証や範囲チェックがコマンドごとに重複していました。
この重複により、同じ意味の検証ロジックが複数箇所に散らばり、将来の機能追加時にメッセージ不一致や修正漏れが起きやすい状態でした。

## ユーザー影響
今回の変更は外部仕様を変えるものではなく、同じ不正入力に対して同じエラーコード (`INVALID_ARGUMENT`) と一貫したヒントを返しやすくするための内部改善です。
結果として、CLI 利用者が受け取るエラーメッセージの揺れを抑え、コマンド追加後も挙動の安定性を維持しやすくなります。

## 根本原因
コマンド実装ごとに `require_non_negative(...)` と個別の条件分岐が直接書かれており、バリデーションの責務が分散していました。
同じ検証規則（例: track は 0 以上）が複製されたため、修正コストと見落としリスクが増えていました。

## 対応内容
`src/ableton_cli/commands/_validation.py` に再利用用のバリデータを追加しました。
- `require_track_index`
- `require_device_index`
- `require_parameter_index`
- `require_float_in_range`

あわせて、以下のコマンド実装を共通ヘルパー経由にリファクタしました。
- `src/ableton_cli/commands/track.py`
- `src/ableton_cli/commands/synth.py`
- `src/ableton_cli/commands/effect.py`

これにより、track/device/parameter の検証と value 範囲検証の重複を削減し、単一の変更点から各コマンドへ反映できる構造に寄せています。

## テストと検証
TDD として先に検証ユーティリティのテストを追加し、実装後に全チェックを通しています。

追加テスト:
- `tests/commands/test_validation.py`

実行したチェック:
- `uv run python -m ableton_cli.dev_checks`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`

いずれも成功しています（`pytest`: 353 passed）。
