### PR TITLE
[codex] Remove host-specific doc paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,13 @@
 - `uv run pytest`
 
 ## Source Documents
-- `/Users/6uclz1/ws/ableton-cli/README.md`
-- `/Users/6uclz1/ws/ableton-cli/CONTRIBUTING.md`
-- `/Users/6uclz1/ws/ableton-cli/skills/ableton-cli/SKILL.md`
-- `/Users/6uclz1/ws/ableton-cli/docs/skills/skill-actions.md`
-- `/Users/6uclz1/ws/ableton-cli/.cursor/rules/ableton-cli.mdc`
+Paths are repository-relative.
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `skills/ableton-cli/SKILL.md`
+- `docs/skills/skill-actions.md`
+- `.cursor/rules/ableton-cli.mdc`
 
 ## Out of Scope for This File
 - No per-session skill availability lists.

--- a/tests/test_docs_hygiene.py
+++ b/tests/test_docs_hygiene.py
@@ -8,15 +8,43 @@ PROTOCOL_DOC = REPO_ROOT / "docs" / "protocol.md"
 QUALITY_HARNESS_TODO_DOC = REPO_ROOT / "docs" / "quality-harness-todo.md"
 GENERATED_MAN_DOC = REPO_ROOT / "docs" / "man" / "generated" / "ableton-cli.1"
 SKILL_DOC = REPO_ROOT / "skills" / "ableton-cli" / "SKILL.md"
+ENVIRONMENT_INDEPENDENT_DOC_GLOBS = (
+    "AGENTS.md",
+    "README.md",
+    "CONTRIBUTING.md",
+    "skills/ableton-cli/SKILL.md",
+    "docs/skills/**/*.md",
+    ".cursor/rules/**/*.mdc",
+    ".cursor/skills/**/*.md",
+)
+HOST_SPECIFIC_MARKERS = ("".join(("6uc", "lz1")), "/" + "Users/")
 
 
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _environment_independent_docs() -> tuple[Path, ...]:
+    paths: set[Path] = set()
+    for pattern in ENVIRONMENT_INDEPENDENT_DOC_GLOBS:
+        paths.update(path for path in REPO_ROOT.glob(pattern) if path.is_file())
+    return tuple(sorted(paths))
+
+
 def test_removed_docs_do_not_exist() -> None:
     assert not PROTOCOL_DOC.exists()
     assert not QUALITY_HARNESS_TODO_DOC.exists()
+
+
+def test_agent_docs_do_not_reference_host_specific_paths() -> None:
+    violations = [
+        f"{path.relative_to(REPO_ROOT)} contains {marker!r}"
+        for path in _environment_independent_docs()
+        for marker in HOST_SPECIFIC_MARKERS
+        if marker in _read(path)
+    ]
+
+    assert violations == []
 
 
 def test_readme_includes_protocol_section() -> None:


### PR DESCRIPTION
## 概要

`AGENTS.md` に残っていたユーザー固有の絶対パスを、リポジトリ相対パスに置き換えました。
あわせて、エージェント向けドキュメントに実ユーザー名や macOS の Home 絶対パスが混入した場合に検出できるテストを追加しています。

```mermaid
flowchart TD
    A["AGENTS.md の絶対パス"] --> B["リポジトリ相対パスへ変更"]
    B --> C["docs hygiene テストで再発検知"]
```

## 変更内容

- `AGENTS.md` の Source Documents を repository-relative path に変更
- `tests/test_docs_hygiene.py` に host-specific marker 検査を追加
- 未追跡の `docs/plan/` は今回の変更対象外

## 確認

- `uv run pytest tests/test_docs_hygiene.py`
- `uv run python -m ableton_cli.dev_checks`
- pre-commit: Ruff checks passed
