### PR TITLE
[codex] Resolve Dependabot security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ package = true
 
 [dependency-groups]
 dev = [
-  "pytest>=8.2.0,<9.0.0",
+  "pytest>=9.0.3,<10.0.0",
   "ruff>=0.6.0,<1.0.0",
   "build>=1.2.1,<2.0.0",
   "pyyaml>=6.0.2,<7.0.0",

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -12,6 +12,12 @@ def _load_ci_workflow() -> dict[str, object]:
     return yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
+def test_ci_workflow_limits_default_token_permissions() -> None:
+    workflow = _load_ci_workflow()
+
+    assert workflow["permissions"] == {"contents": "read"}
+
+
 def test_ci_workflow_configures_dev_checks_reports() -> None:
     workflow = _load_ci_workflow()
     jobs = workflow["jobs"]

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2.1,<2.0.0" },
-    { name = "pytest", specifier = ">=8.2.0,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "ruff", specifier = ">=0.6.0,<1.0.0" },
 ]
@@ -164,11 +164,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -193,9 +193,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要
Dependabot / GitHub Security alert と Code scanning で検出されていたセキュリティ指摘に対応しました。

- `pytest`: `8.4.2` から `9.0.3` へ更新し、dev 依存の制約を `>=9.0.3,<10.0.0` に変更
- `Pygments`: `2.19.2` から `2.20.0` へ更新
- GitHub Actions の `GITHUB_TOKEN` 権限を workflow 全体で `contents: read` に制限
- CI workflow の token permissions を回帰テストで固定

## 対応した警告

```mermaid
flowchart TD
    A[GitHub security findings] --> B[Dependabot: pytest < 9.0.3]
    A --> C[Dependabot: Pygments < 2.20.0]
    A --> D[Code scanning: actions/missing-workflow-permissions]
    B --> E[pyproject.toml の dev 制約を更新]
    C --> F[uv.lock を patched version に更新]
    D --> G[.github/workflows/ci.yml に permissions を追加]
    E --> H[pytest 9.0.3]
    F --> I[Pygments 2.20.0]
    G --> J[GITHUB_TOKEN: contents read only]
```

## 影響
ランタイム依存には変更ありません。開発・テスト用依存の更新と、CI workflow のデフォルト token 権限の最小化です。

## 検証
- `uv run pytest tests/test_ci_workflow.py`（Red 確認後 Green）
- `uv run python -m ableton_cli.dev_checks`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`（604 passed）