### PR TITLE
Add release automation: unified v0.5.0, bundled wheel assets, auto-release on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.tag.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read package version
+        id: version
+        run: |
+          VERSION="$(python3 -c "
+          import re, pathlib
+          text = pathlib.Path('src/ableton_cli/__init__.py').read_text()
+          print(re.search(r'__version__ = \"([^\"]+)\"', text).group(1))
+          ")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Package version: $VERSION"
+
+      - name: Check whether tag already exists
+        id: tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" > /dev/null; then
+            echo "Tag v$VERSION already exists; nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag v$VERSION does not exist; releasing."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Verify version consistency
+        run: |
+          PKG_VERSION="$(uv run python -c 'import ableton_cli; print(ableton_cli.__version__)')"
+          RS_VERSION="$(uv run python -c 'import sys; sys.path.insert(0, "."); from remote_script.AbletonCliRemote.command_backend_contract import REMOTE_SCRIPT_VERSION; print(REMOTE_SCRIPT_VERSION)')"
+          echo "release=$VERSION package=$PKG_VERSION remote_script=$RS_VERSION"
+          test "$VERSION" = "$PKG_VERSION"
+          test "$VERSION" = "$RS_VERSION"
+
+      - name: Run checks
+        run: uv run python -m ableton_cli.dev_checks
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Verify wheel contents
+        run: |
+          python3 -c "
+          import glob, zipfile
+          wheel = glob.glob('dist/*.whl')[0]
+          names = zipfile.ZipFile(wheel).namelist()
+          assert any(
+              n.startswith('ableton_cli/_bundled/remote_script/AbletonCliRemote/') for n in names
+          ), 'remote_script assets missing from wheel'
+          assert 'ableton_cli/_bundled/skills/ableton-cli/SKILL.md' in names, 'skill asset missing from wheel'
+          assert not any(
+              '__pycache__' in n or n.endswith('.pyc') for n in names
+          ), 'bytecode leaked into wheel'
+          print(f'{wheel}: bundled assets OK ({len(names)} files)')
+          "
+
+      - name: Smoke test wheel install
+        run: |
+          uv tool install --from ./dist/*.whl ableton-cli
+          cd "$RUNNER_TEMP"
+          INSTALLED_VERSION="$(ableton-cli --version)"
+          echo "installed version: $INSTALLED_VERSION"
+          test "$INSTALLED_VERSION" = "$VERSION"
+          mkdir -p "$HOME/Ableton/User Library/Remote Scripts"
+          ableton-cli --output json install-remote-script --yes
+          test -f "$HOME/Ableton/User Library/Remote Scripts/AbletonCliRemote/command_backend_contract.py"
+          ableton-cli --output json install-skill --target claude --dry-run --yes
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v$VERSION" dist/* \
+            --title "v$VERSION" \
+            --target "$GITHUB_SHA" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ It is designed for both humans and automation (Skills/agents), with stable JSON 
 - Python 3.10+
 - [uv](https://docs.astral.sh/uv/)
 
+## Install
+
+Install as a standalone tool with uv (no checkout needed). Use this repository's
+URL (shown under the GitHub "Code" button) as `<repo-url>`:
+
+```bash
+uv tool install "git+<repo-url>"
+# or pin a release tag:
+uv tool install "git+<repo-url>@vX.Y.Z"
+```
+
+Then use `ableton-cli` directly (no `uv run` prefix):
+
+```bash
+ableton-cli install-remote-script --yes
+ableton-cli doctor
+```
+
+Release tags and prebuilt artifacts are published on this repository's GitHub
+Releases page. To work from source instead, follow Quick Setup below.
+
 ## Quick Setup
 
 1. Install dependencies:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing
+
+Releases are fully automated: merging a version bump to `main` triggers the
+`Release` workflow (`.github/workflows/release.yml`), which creates the git tag
+and the GitHub Release with built `sdist`/`wheel` artifacts attached. No manual
+tagging is required.
+
+There is a single version for the whole repository: the CLI package version
+(`ableton_cli.__version__`) and the Remote Script version
+(`REMOTE_SCRIPT_VERSION`) must always be equal. A unit test enforces this.
+
+## Steps
+
+1. In a PR, bump the version in both places to the same `X.Y.Z`:
+   - `src/ableton_cli/__init__.py` — `__version__` (single source for the
+     package version; `pyproject.toml` reads it via `[tool.hatch.version]`)
+   - `remote_script/AbletonCliRemote/command_backend_contract.py` —
+     `REMOTE_SCRIPT_VERSION` (kept as a literal because the Remote Script runs
+     standalone inside Ableton Live and cannot import `ableton_cli`)
+2. Refresh version strings in doc examples if they reference the old version:
+   - `skills/ableton-cli/SKILL.md` (ping example payload)
+   - `docs/skills/examples/ping.json`
+3. Refresh the lockfile and run the checks:
+
+   ```bash
+   uv lock
+   uv run python -m ableton_cli.dev_checks
+   ```
+
+4. Merge the PR into `main`.
+
+## What the workflow does
+
+On every push to `main`:
+
+1. `check` job reads `__version__` and looks for an existing `vX.Y.Z` tag.
+   If the tag exists (no version bump), the workflow stops — normal merges are
+   a no-op.
+2. `release` job (only when the tag is new):
+   - verifies package version == Remote Script version
+   - runs `ableton_cli.dev_checks`
+   - builds sdist + wheel with `uv build`
+   - asserts the wheel bundles `remote_script/` and `skills/` assets under
+     `ableton_cli/_bundled/` with no bytecode
+   - smoke-tests the wheel: `uv tool install`, `--version`,
+     `install-remote-script`, `install-skill --dry-run`
+   - creates the tag and the GitHub Release (`gh release create vX.Y.Z dist/*
+     --generate-notes`)
+
+## Verifying a release
+
+```bash
+uv tool install git+https://github.com/6uclz1/ableton-cli@vX.Y.Z
+ableton-cli --version
+```

--- a/docs/skills/examples/ping.json
+++ b/docs/skills/examples/ping.json
@@ -6,7 +6,7 @@
     "host": "127.0.0.1",
     "port": 8765,
     "protocol_version": 2,
-    "remote_script_version": "0.3.0",
+    "remote_script_version": "0.5.0",
     "rtt_ms": 2.31
   },
   "error": null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ableton-cli"
-version = "0.1.0"
+dynamic = ["version"]
 description = "CLI tool to control and inspect Ableton Live via a local Remote Script"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,10 @@ authors = [
   { name = "ableton-cli contributors" }
 ]
 dependencies = [
-  "typer>=0.12.0,<1.0.0",
+  # typer 0.26+ vendors click, breaking the direct click.get_current_context()
+  # integration in app_factory; keep both pinned to the click-based line.
+  "typer>=0.12.0,<0.26.0",
+  "click>=8.0.0,<9.0.0",
   "platformdirs>=4.2.0,<5.0.0",
   "tomli>=2.0.1,<3.0.0",
 ]
@@ -20,6 +23,30 @@ ableton-cli = "ableton_cli.cli:main"
 [build-system]
 requires = ["hatchling>=1.26.0,<2.0.0"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/ableton_cli/__init__.py"
+
+[tool.hatch.build]
+exclude = [
+  "**/__pycache__",
+  "**/*.pyc",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ableton_cli"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"remote_script/AbletonCliRemote" = "ableton_cli/_bundled/remote_script/AbletonCliRemote"
+"skills/ableton-cli" = "ableton_cli/_bundled/skills/ableton-cli"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "src/ableton_cli",
+  "remote_script",
+  "skills",
+  "README.md",
+]
 
 [tool.uv]
 package = true

--- a/remote_script/AbletonCliRemote/command_backend_contract.py
+++ b/remote_script/AbletonCliRemote/command_backend_contract.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol
 from .note_fields import NOTE_FIELD_SPECS
 
 PROTOCOL_VERSION = 2
-REMOTE_SCRIPT_VERSION = "0.4.0"
+REMOTE_SCRIPT_VERSION = "0.5.0"
 MIN_BPM = 20.0
 MAX_BPM = 999.0
 MIN_VOLUME = 0.0

--- a/skills/ableton-cli/SKILL.md
+++ b/skills/ableton-cli/SKILL.md
@@ -464,7 +464,7 @@ uv run ableton-cli --output json ping
       "host": "127.0.0.1",
       "port": 8765,
       "protocol_version": 2,
-      "remote_script_version": "0.4.0",
+      "remote_script_version": "0.5.0",
       "rtt_ms": 2.31
     },
   "error": null

--- a/src/ableton_cli/__init__.py
+++ b/src/ableton_cli/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.5.0"

--- a/src/ableton_cli/installer.py
+++ b/src/ableton_cli/installer.py
@@ -14,9 +14,25 @@ SKILL_DIR_NAME = "ableton-cli"
 SKILL_FILE_NAME = "SKILL.md"
 CODEX_HOME_ENV_VAR = "CODEX_HOME"
 
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_BUNDLED_DIR = _PACKAGE_DIR / "_bundled"
+_REPO_ROOT = _PACKAGE_DIR.parents[1]
+
+
+def _first_existing(candidates: list[Path]) -> Path:
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[-1]
+
 
 def remote_script_source_dir() -> Path:
-    return Path(__file__).resolve().parents[2] / "remote_script" / REMOTE_SCRIPT_DIR_NAME
+    return _first_existing(
+        [
+            _BUNDLED_DIR / "remote_script" / REMOTE_SCRIPT_DIR_NAME,
+            _REPO_ROOT / "remote_script" / REMOTE_SCRIPT_DIR_NAME,
+        ]
+    )
 
 
 def _select_target_roots(candidates: list[Path]) -> list[Path]:
@@ -74,7 +90,7 @@ def install_remote_script(
             target_root.mkdir(parents=True, exist_ok=True)
             if target.exists() and backup_path is not None:
                 shutil.move(str(target), str(backup_path))
-            shutil.copytree(source, target)
+            shutil.copytree(source, target, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
 
         targets.append(str(target))
 
@@ -90,7 +106,12 @@ def install_remote_script(
 
 
 def skill_source_file() -> Path:
-    return Path(__file__).resolve().parents[2] / "skills" / SKILL_DIR_NAME / SKILL_FILE_NAME
+    return _first_existing(
+        [
+            _BUNDLED_DIR / "skills" / SKILL_DIR_NAME / SKILL_FILE_NAME,
+            _REPO_ROOT / "skills" / SKILL_DIR_NAME / SKILL_FILE_NAME,
+        ]
+    )
 
 
 def _resolve_codex_home(codex_home: Path | None) -> Path:

--- a/tests/test_installer_source_resolution.py
+++ b/tests/test_installer_source_resolution.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ableton_cli import installer
+from ableton_cli.installer import (
+    REMOTE_SCRIPT_DIR_NAME,
+    SKILL_DIR_NAME,
+    SKILL_FILE_NAME,
+    install_remote_script,
+    remote_script_source_dir,
+    skill_source_file,
+)
+
+
+class _PlatformPathsStub:
+    def __init__(self, candidates: list[Path]) -> None:
+        self._candidates = candidates
+
+    def remote_script_candidate_dirs(self) -> list[Path]:
+        return self._candidates
+
+
+def test_remote_script_source_dir_resolves_repo_checkout() -> None:
+    source = remote_script_source_dir()
+
+    assert source.is_dir()
+    assert (source / "__init__.py").is_file()
+    assert (source / "command_backend_contract.py").is_file()
+
+
+def test_skill_source_file_resolves_repo_checkout() -> None:
+    source = skill_source_file()
+
+    assert source.is_file()
+    assert source.name == SKILL_FILE_NAME
+
+
+def test_bundled_assets_win_over_repo_checkout(monkeypatch, tmp_path: Path) -> None:
+    bundled = tmp_path / "_bundled"
+    bundled_remote = bundled / "remote_script" / REMOTE_SCRIPT_DIR_NAME
+    bundled_remote.mkdir(parents=True)
+    bundled_skill = bundled / "skills" / SKILL_DIR_NAME / SKILL_FILE_NAME
+    bundled_skill.parent.mkdir(parents=True)
+    bundled_skill.write_text("# skill\n", encoding="utf-8")
+
+    monkeypatch.setattr(installer, "_BUNDLED_DIR", bundled)
+
+    assert remote_script_source_dir() == bundled_remote
+    assert skill_source_file() == bundled_skill
+
+
+def test_missing_sources_return_last_candidate_for_error_paths(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(installer, "_BUNDLED_DIR", tmp_path / "missing_bundled")
+    monkeypatch.setattr(installer, "_REPO_ROOT", tmp_path / "missing_repo")
+
+    assert remote_script_source_dir() == (
+        tmp_path / "missing_repo" / "remote_script" / REMOTE_SCRIPT_DIR_NAME
+    )
+    assert skill_source_file() == (
+        tmp_path / "missing_repo" / "skills" / SKILL_DIR_NAME / SKILL_FILE_NAME
+    )
+
+
+def test_install_remote_script_skips_bytecode(monkeypatch, tmp_path: Path) -> None:
+    source_root = tmp_path / "source" / REMOTE_SCRIPT_DIR_NAME
+    source_root.mkdir(parents=True)
+    (source_root / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+    pycache = source_root / "__pycache__"
+    pycache.mkdir()
+    (pycache / "__init__.cpython-311.pyc").write_bytes(b"\x00")
+    (source_root / "stale.pyc").write_bytes(b"\x00")
+
+    target_root = tmp_path / "ableton" / "Remote Scripts"
+    target_root.mkdir(parents=True)
+
+    monkeypatch.setattr("ableton_cli.installer.remote_script_source_dir", lambda: source_root)
+    platform_paths = _PlatformPathsStub(candidates=[target_root])
+
+    install_remote_script(dry_run=False, yes=True, platform_paths=platform_paths)
+
+    installed = target_root / REMOTE_SCRIPT_DIR_NAME
+    assert (installed / "__init__.py").exists()
+    assert not (installed / "__pycache__").exists()
+    assert not (installed / "stale.pyc").exists()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,6 +6,7 @@ import typer
 import ableton_cli.version as version_module
 from ableton_cli import __version__
 from ableton_cli.errors import ExitCode
+from remote_script.AbletonCliRemote.command_backend_contract import REMOTE_SCRIPT_VERSION
 
 
 def test_version_callback_prints_and_exits(monkeypatch) -> None:
@@ -21,3 +22,7 @@ def test_version_callback_prints_and_exits(monkeypatch) -> None:
 
 def test_version_callback_ignores_false() -> None:
     version_module.version_callback(False)
+
+
+def test_remote_script_version_matches_package_version() -> None:
+    assert REMOTE_SCRIPT_VERSION == __version__

--- a/uv.lock
+++ b/uv.lock
@@ -4,9 +4,9 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ableton-cli"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "platformdirs" },
     { name = "tomli" },
     { name = "typer" },
@@ -22,9 +22,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0.0,<9.0.0" },
     { name = "platformdirs", specifier = ">=4.2.0,<5.0.0" },
     { name = "tomli", specifier = ">=2.0.1,<3.0.0" },
-    { name = "typer", specifier = ">=0.12.0,<1.0.0" },
+    { name = "typer", specifier = ">=0.12.0,<0.26.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Introduces a release process for a repo that previously had zero git tags and a fixed `0.1.0` version.

- **Unified version v0.5.0**: `__version__` in `src/ableton_cli/__init__.py` is now the single source (hatchling reads it via `[tool.hatch.version]`; `version` removed from `[project]`). `REMOTE_SCRIPT_VERSION` is unified at the same value — it stays a literal (the Remote Script cannot import `ableton_cli` inside Live) but a new test enforces equality so they cannot drift.
- **Auto-release on main push** (`.github/workflows/release.yml`): a fast `check` job reads the version and looks for an existing `v{version}` tag. When the tag is missing (i.e. a version bump was merged), the `release` job verifies version consistency, runs `dev_checks`, builds sdist+wheel, asserts bundled wheel contents, smoke-tests the installed wheel (`--version`, `install-remote-script`, `install-skill --dry-run`), and creates the tag + GitHub Release with `dist/*` attached via `gh release create --generate-notes`. No PyPI publishing. Merges without a bump exit at the check job.
- **Bundled wheel assets**: `remote_script/` and `skills/` are force-included into the wheel under `ableton_cli/_bundled/`, and `installer.py` resolves sources bundled-first with repo-checkout fallback — so `uv tool install "git+<repo-url>"` yields a fully working tool including `install-remote-script` / `install-skill`. `copytree` now ignores `__pycache__`/`*.pyc`.
- **Dependency fix found by the smoke test**: typer 0.26+ vendors click, which breaks the direct `click.get_current_context()` call in `app_factory.py` (verified crash with typer 0.27.0 on a fresh resolve — this would have broken any fresh `uv sync` regardless of this PR). Pinned `typer>=0.12,<0.26` and declared `click>=8,<9` explicitly; migrating to `typer.Context` is follow-up work.
- **Docs**: README gains an Install section (placeholder repo URL per the docs-hygiene policy); new `RELEASING.md` documents the bump-and-merge flow.

## Test plan

- `uv run python -m ableton_cli.dev_checks` — 923 passed (includes new `tests/test_installer_source_resolution.py` and the version-sync test)
- `uv run python -m build` (CI-parity sdist→wheel); asserted wheel/sdist bundle assets and contain no bytecode
- Out-of-repo smoke test: `uv tool install --from dist/*.whl ableton-cli` → `--version` = 0.5.0, `install-remote-script --dry-run` and `install-skill --dry-run` both resolve sources from `site-packages/ableton_cli/_bundled/...`
- After merge: the release workflow should detect the missing `v0.5.0` tag and publish the first release automatically; a follow-up no-bump push should exit at the check job

🤖 Generated with [Claude Code](https://claude.com/claude-code)