### PR TITLE
タイムアウト再試行による二重適用を止める

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,31 @@ Compatibility validation is now explicit:
 - `uv run ableton-cli ping` for protocol/version metadata
 - `uv run ableton-cli doctor` for supported command integrity checks
 
+### Batch step retries
+
+Batch steps run once unless the step opts in with a `retry` object:
+
+```json
+{"name": "tracks_list", "args": {}, "retry": {"max_attempts": 3, "backoff_ms": 200}}
+```
+
+`retry.on` defaults to `["REMOTE_BUSY"]`. `REMOTE_BUSY` is rejected by the
+Remote Script before the command is queued, so a retry cannot double-apply it.
+
+`TIMEOUT` is not retried by default, and listing it in `retry.on` fails with
+`INVALID_ARGUMENT` unless the step's remote command is idempotent (read
+commands). A timed-out command may already have been applied by Live, so
+retrying it would apply it twice.
+
+A step that fails with `TIMEOUT` reports `error.details.may_have_executed`:
+
+- `true` — Live had already started the command; inspect the set before retrying
+- `false` — the command was cancelled before it ran and can be resent safely
+- `null` — no structured answer reached the CLI; assume it may have been applied
+
+A `TIMEOUT` with `may_have_executed: true` is never retried, even when
+`retry.on` lists `TIMEOUT`.
+
 ## Exit Codes
 
 - `0` success

--- a/skills/ableton-cli/SKILL.md
+++ b/skills/ableton-cli/SKILL.md
@@ -422,6 +422,9 @@ uv run ableton-cli --show-completion
   - Example: `uv run ableton-cli effect parameter set -- -2.0 --track-index 0 --device-index 0 --parameter-index 7`
 - For low-latency repeated automation operations, prefer `uv run ableton-cli batch stream`.
 - Capability and compatibility checks are explicit through `uv run ableton-cli ping` and `uv run ableton-cli doctor`.
+- Batch steps run once unless the step declares `retry`. `retry.on` defaults to `["REMOTE_BUSY"]`.
+  - Listing `TIMEOUT` in `retry.on` fails with `INVALID_ARGUMENT` unless the step's remote command is idempotent (read commands). A timed-out write may already have been applied, so a retry would double-apply it.
+  - A `TIMEOUT` step failure reports `error.details.may_have_executed` (`true` / `false` / `null` when unknown). Inspect the set with a read command before resending anything other than `false`.
 - Destructive master device deletion requires `--yes`. Live API unsupported operations fail explicitly with `not_supported_by_live_api`.
 - Standard wrapper commands (`synth <type> ...`, `effect <type> ...`) are strict and intentionally fail if required parameter names are missing.
   - If you get `Missing required standard ... keys`, use generic commands instead:

--- a/src/ableton_cli/client/transport.py
+++ b/src/ableton_cli/client/transport.py
@@ -14,11 +14,37 @@ class JsonTransport(Protocol):
     def close(self) -> None: ...
 
 
+#: Extra time the client waits on the socket beyond the logical request deadline
+#: it hands to the Remote Script in ``meta.request_timeout_ms``.
+#:
+#: The Remote Script detects its own main-thread wait expiring at exactly
+#: ``request_timeout_ms`` and only then writes a structured TIMEOUT response
+#: carrying ``may_have_executed``. If the client's socket read used the same
+#: deadline both sides would expire at the same instant — and the client, which
+#: starts its clock first, normally wins — so that signal would be thrown away
+#: and callers could never tell whether the command had already been applied.
+#: The grace window only delays how long a hung request takes to fail; it never
+#: turns a timeout into a success.
+_SOCKET_GRACE_MS = 2000
+
+
+def socket_timeout_ms(request_timeout_ms: int) -> int:
+    """Derive the socket read deadline from the logical request deadline.
+
+    Single derivation point: callers pass ``settings.timeout_ms`` as the request
+    deadline and must never compute a socket deadline of their own.
+    """
+    return request_timeout_ms + _SOCKET_GRACE_MS
+
+
 class TcpJsonlTransport:
     def __init__(self, host: str, port: int, timeout_ms: int) -> None:
         self.host = host
         self.port = port
-        self.timeout_s = timeout_ms / 1000
+        # Connecting is not subject to the main-thread wait the grace covers, so
+        # connection setup keeps the plain request deadline.
+        self.request_timeout_s = timeout_ms / 1000
+        self.socket_timeout_s = socket_timeout_ms(timeout_ms) / 1000
         self._sock: socket.socket | None = None
         self._file: Any | None = None
 
@@ -27,7 +53,7 @@ class TcpJsonlTransport:
             return
 
         try:
-            sock = socket.create_connection((self.host, self.port), timeout=self.timeout_s)
+            sock = socket.create_connection((self.host, self.port), timeout=self.request_timeout_s)
         except TimeoutError as exc:
             raise AppError(
                 error_code=ErrorCode.TIMEOUT,
@@ -50,7 +76,7 @@ class TcpJsonlTransport:
                 exit_code=ExitCode.ABLETON_NOT_CONNECTED,
             ) from exc
 
-        sock.settimeout(self.timeout_s)
+        sock.settimeout(self.socket_timeout_s)
         self._sock = sock
         self._file = sock.makefile("rwb")
 

--- a/src/ableton_cli/command_specs.py
+++ b/src/ableton_cli/command_specs.py
@@ -385,6 +385,47 @@ def command_spec_map() -> dict[str, CommandSpec]:
     return {spec.command_name: spec for spec in command_specs()}
 
 
+_SIDE_EFFECT_SEVERITY: dict[SideEffectKind, int] = {"read": 0, "write": 1, "destructive": 2}
+
+
+def _merge_side_effects(left: SideEffectSpec, right: SideEffectSpec) -> SideEffectSpec:
+    """Combine two declarations for the same remote command, safe side first."""
+    kind = max(left.kind, right.kind, key=lambda item: _SIDE_EFFECT_SEVERITY[item])
+    return SideEffectSpec(
+        kind=kind,
+        idempotent=left.idempotent and right.idempotent,
+        requires_confirmation=left.requires_confirmation or right.requires_confirmation,
+    )
+
+
+def remote_command_spec_map() -> dict[str, CommandSpec]:
+    """Look up a ``CommandSpec`` by remote command name.
+
+    Batch steps name remote commands (``add_notes_to_clip``) while
+    ``command_spec_map`` is keyed by CLI command names (``clip notes add``).
+    The mapping is many-to-one — ``clip notes import-browser`` and
+    ``browser load`` both dispatch ``load_instrument_or_effect`` — so colliding
+    entries are merged on the safe side: the strongest side-effect kind wins,
+    ``idempotent`` is the conjunction, and ``requires_confirmation`` the
+    disjunction. ``command_name`` is left holding the first CLI name in sorted
+    order and must not be used as an identity.
+    """
+    merged: dict[str, CommandSpec] = {}
+    for spec in command_specs():
+        if spec.remote_command is None:
+            continue
+        existing = merged.get(spec.remote_command)
+        if existing is None:
+            merged[spec.remote_command] = spec
+            continue
+        merged[spec.remote_command] = CommandSpec(
+            command_name=existing.command_name,
+            remote_command=spec.remote_command,
+            side_effect=_merge_side_effects(existing.side_effect, spec.side_effect),
+        )
+    return merged
+
+
 def remote_command_names() -> set[str]:
     return {
         spec.remote_command for spec in command_specs() if spec.remote_command is not None

--- a/src/ableton_cli/commands/batch.py
+++ b/src/ableton_cli/commands/batch.py
@@ -9,16 +9,39 @@ from typing import Annotated, Any
 import typer
 
 from ..capabilities import parse_supported_commands, required_remote_commands
+from ..command_specs import remote_command_spec_map
 from ..errors import AppError, ErrorCode, ExitCode
 from ..runtime import execute_command, get_client, get_runtime
 from ._validation import invalid_argument, require_non_empty_string
 
 batch_app = typer.Typer(help="Batch commands", no_args_is_help=True)
 _ASSERT_OPERATORS = frozenset({"eq", "ne", "gt", "gte", "lt", "lte"})
-_DEFAULT_RETRY_CODES = ("TIMEOUT", "REMOTE_BUSY")
+#: REMOTE_BUSY is the only code that is safe to retry blindly: the Remote Script
+#: raises it from `_execute_command_from_server_thread` on the queue-depth check,
+#: which runs *before* `self._queue.put()`, so a REMOTE_BUSY request provably
+#: never reached Live's main thread and had zero side effects.
+#: TIMEOUT is deliberately absent — a timed-out request may already have been
+#: applied, so retrying it double-applies non-idempotent commands.
+_DEFAULT_RETRY_CODES = ("REMOTE_BUSY",)
 
 
-def _parse_retry_object(raw_retry: Any, *, step_index: int) -> dict[str, Any] | None:
+def _reject_unsafe_timeout_retry(*, step_index: int, command_name: str) -> None:
+    spec = remote_command_spec_map().get(command_name)
+    if spec is not None and spec.side_effect.idempotent:
+        return
+    known = "" if spec is not None else " with unknown idempotency"
+    raise invalid_argument(
+        message=f"steps[{step_index}].retry.on may not include TIMEOUT for {command_name!r}",
+        hint=(
+            f"TIMEOUT retry is unsafe for non-idempotent command {command_name!r}{known}; "
+            "the command may have already been applied. Remove TIMEOUT from retry.on."
+        ),
+    )
+
+
+def _parse_retry_object(
+    raw_retry: Any, *, step_index: int, command_name: str
+) -> dict[str, Any] | None:
     if raw_retry is None:
         return None
     if not isinstance(raw_retry, dict):
@@ -60,6 +83,9 @@ def _parse_retry_object(raw_retry: Any, *, step_index: int) -> dict[str, Any] | 
                 hint=f"steps[{step_index}].retry.on[{code_index}] must be non-empty.",
             )
         )
+
+    if "TIMEOUT" in retry_on:
+        _reject_unsafe_timeout_retry(step_index=step_index, command_name=command_name)
 
     return {
         "max_attempts": raw_max_attempts,
@@ -248,7 +274,9 @@ def _parse_batch_object(payload: Any, *, source_name: str) -> dict[str, Any]:
         parsed_step = {
             "name": name,
             "args": raw_args,
-            "retry": _parse_retry_object(raw_step.get("retry"), step_index=index),
+            "retry": _parse_retry_object(
+                raw_step.get("retry"), step_index=index, command_name=name
+            ),
             "assert": _parse_assert_object(raw_step.get("assert"), step_index=index),
         }
         steps.append(parsed_step)
@@ -477,6 +505,23 @@ def _run_preflight(
     }
 
 
+def _annotate_step_timeout(exc: AppError, *, step_index: int, name: str) -> None:
+    """Surface on a timed-out step whether Live may already have applied it.
+
+    The Remote Script reports ``may_have_executed`` once its main-thread wait
+    expires. ``None`` means no structured answer reached the client at all, so
+    the caller must assume the command might have landed.
+    """
+    if exc.error_code != ErrorCode.TIMEOUT:
+        return
+    exc.details = {
+        **exc.details,
+        "step_index": step_index,
+        "name": name,
+        "may_have_executed": exc.details.get("may_have_executed"),
+    }
+
+
 def _execute_step(
     client: Any,
     *,
@@ -485,7 +530,11 @@ def _execute_step(
 ) -> tuple[dict[str, Any], int]:
     retry = step["retry"]
     if retry is None:
-        result = client.execute_remote_command(step["name"], step["args"])
+        try:
+            result = client.execute_remote_command(step["name"], step["args"])
+        except AppError as exc:
+            _annotate_step_timeout(exc, step_index=step_index, name=step["name"])
+            raise
         return result, 1
 
     max_attempts = retry["max_attempts"]
@@ -499,6 +548,12 @@ def _execute_step(
             result = client.execute_remote_command(step["name"], step["args"])
             return result, attempt
         except AppError as exc:
+            _annotate_step_timeout(exc, step_index=step_index, name=step["name"])
+            # The Remote Script could not cancel this request before Live began
+            # dispatching it, so a resend would apply the command a second time.
+            # This outranks retry.on: even an opt-in retry must not double-apply.
+            if exc.details.get("may_have_executed") is True:
+                raise
             if exc.error_code not in retry_on:
                 raise
             if attempt >= max_attempts:

--- a/tests/test_ableton_client.py
+++ b/tests/test_ableton_client.py
@@ -55,6 +55,17 @@ def test_client_non_ping_command_sends_single_request_without_preflight(monkeypa
     assert [request["name"] for request in requests] == ["song_info"]
 
 
+def test_client_socket_deadline_outlives_the_advertised_request_timeout(monkeypatch) -> None:
+    settings = _settings()
+    client = AbletonClient(settings)
+    requests = _capture_requests(monkeypatch, client)
+
+    client.song_info()
+
+    assert requests[0]["meta"]["request_timeout_ms"] == settings.timeout_ms
+    assert client.transport.socket_timeout_s > settings.timeout_ms / 1000
+
+
 def test_client_does_not_retry_read_command_on_timeout(monkeypatch) -> None:
     client = AbletonClient(_settings())
     requests: list[dict[str, Any]] = []

--- a/tests/test_batch_retry_safety.py
+++ b/tests/test_batch_retry_safety.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from ableton_cli.errors import AppError, ExitCode
+
+
+def _timeout_error(*, may_have_executed: bool | None = None) -> AppError:
+    details: dict[str, Any] = {}
+    if may_have_executed is not None:
+        details["may_have_executed"] = may_have_executed
+    return AppError(
+        error_code="TIMEOUT",
+        message="Timed out waiting for Ableton main thread",
+        hint="Retry the command while Ableton Live is responsive.",
+        exit_code=ExitCode.TIMEOUT,
+        details=details,
+    )
+
+
+class _StepClientStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._responses: dict[str, list[dict[str, Any] | AppError]] = {}
+
+    def set_responses(self, name: str, items: list[dict[str, Any] | AppError]) -> None:
+        self._responses[name] = list(items)
+
+    def execute_remote_command(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((name, args))
+        queue = self._responses.get(name)
+        if queue:
+            item = queue.pop(0)
+            if isinstance(item, AppError):
+                raise item
+            return item
+        return {"ok": True, "name": name}
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> _StepClientStub:
+    from ableton_cli.commands import batch
+
+    stub = _StepClientStub()
+    monkeypatch.setattr(batch, "get_client", lambda _ctx: stub)
+    return stub
+
+
+def _run_batch(runner, cli_app, steps: list[dict[str, Any]]):  # noqa: ANN001, ANN202
+    return runner.invoke(
+        cli_app,
+        ["--output", "json", "batch", "run", "--steps-json", json.dumps({"steps": steps})],
+    )
+
+
+def test_timeout_retry_is_rejected_for_a_non_idempotent_command(
+    runner, cli_app, client: _StepClientStub
+) -> None:
+    result = _run_batch(
+        runner,
+        cli_app,
+        [
+            {
+                "name": "add_notes_to_clip",
+                "args": {},
+                "retry": {"max_attempts": 3, "on": ["TIMEOUT"]},
+            }
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "INVALID_ARGUMENT"
+    assert "add_notes_to_clip" in payload["error"]["hint"]
+    assert client.calls == []
+
+
+def test_timeout_retry_is_allowed_for_an_idempotent_command(
+    runner, cli_app, client: _StepClientStub
+) -> None:
+    client.set_responses("tracks_list", [_timeout_error(), {"tracks": []}])
+
+    result = _run_batch(
+        runner,
+        cli_app,
+        [
+            {
+                "name": "tracks_list",
+                "args": {},
+                "retry": {"max_attempts": 3, "backoff_ms": 0, "on": ["TIMEOUT"]},
+            }
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["result"]["results"][0]["attempts"] == 2
+
+
+def test_default_retry_codes_exclude_timeout(runner, cli_app, client: _StepClientStub) -> None:
+    from ableton_cli.commands.batch import _DEFAULT_RETRY_CODES
+
+    assert "TIMEOUT" not in _DEFAULT_RETRY_CODES
+    assert "REMOTE_BUSY" in _DEFAULT_RETRY_CODES
+
+    client.set_responses("add_notes_to_clip", [_timeout_error(), {"ok": True}])
+
+    result = _run_batch(
+        runner,
+        cli_app,
+        [{"name": "add_notes_to_clip", "args": {}, "retry": {"max_attempts": 3}}],
+    )
+
+    assert result.exit_code == 12
+    assert len(client.calls) == 1
+
+
+def test_step_without_retry_is_executed_once(runner, cli_app, client: _StepClientStub) -> None:
+    client.set_responses("add_notes_to_clip", [_timeout_error(), {"ok": True}])
+
+    result = _run_batch(runner, cli_app, [{"name": "add_notes_to_clip", "args": {}}])
+
+    assert result.exit_code == 12
+    assert len(client.calls) == 1
+
+
+def test_timeout_that_may_have_executed_is_never_retried(
+    runner, cli_app, client: _StepClientStub
+) -> None:
+    client.set_responses(
+        "tracks_list",
+        [_timeout_error(may_have_executed=True), {"tracks": []}],
+    )
+
+    result = _run_batch(
+        runner,
+        cli_app,
+        [
+            {
+                "name": "tracks_list",
+                "args": {},
+                "retry": {"max_attempts": 3, "backoff_ms": 0, "on": ["TIMEOUT"]},
+            }
+        ],
+    )
+
+    assert result.exit_code == 12
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "TIMEOUT"
+    assert len(client.calls) == 1
+
+
+def test_step_timeout_exposes_may_have_executed(runner, cli_app, client: _StepClientStub) -> None:
+    client.set_responses("add_notes_to_clip", [_timeout_error(may_have_executed=True)])
+
+    result = _run_batch(runner, cli_app, [{"name": "add_notes_to_clip", "args": {}}])
+
+    payload = json.loads(result.stdout)
+    assert payload["error"]["details"]["may_have_executed"] is True
+    assert payload["error"]["details"]["step_index"] == 0
+
+
+def test_step_timeout_without_remote_signal_reports_unknown(
+    runner, cli_app, client: _StepClientStub
+) -> None:
+    client.set_responses("add_notes_to_clip", [_timeout_error()])
+
+    result = _run_batch(runner, cli_app, [{"name": "add_notes_to_clip", "args": {}}])
+
+    payload = json.loads(result.stdout)
+    assert payload["error"]["details"]["may_have_executed"] is None

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -77,3 +77,37 @@ def test_read_only_remote_commands_are_derived_from_contract_metadata() -> None:
     from ableton_cli.contracts.registry import read_only_remote_command_names
 
     assert read_only_remote_commands() == read_only_remote_command_names()
+
+
+def test_remote_command_spec_map_covers_every_dispatchable_remote_command() -> None:
+    from ableton_cli.command_specs import (
+        _REMOTE_COMMAND_ALIASES,
+        remote_command_names,
+        remote_command_spec_map,
+    )
+
+    assert set(remote_command_spec_map()) == remote_command_names() - _REMOTE_COMMAND_ALIASES
+
+
+def test_remote_command_spec_map_merges_collisions_on_the_safe_side() -> None:
+    from ableton_cli.command_specs import command_spec_map, remote_command_spec_map
+
+    cli_specs = command_spec_map()
+    # `browser load` (write) and `clip notes import-browser` (destructive) both
+    # dispatch load_instrument_or_effect.
+    assert cli_specs["browser load"].side_effect.kind == "write"
+    assert cli_specs["clip notes import-browser"].side_effect.kind == "destructive"
+
+    merged = remote_command_spec_map()["load_instrument_or_effect"].side_effect
+    assert merged.kind == "destructive"
+    assert merged.idempotent is False
+    assert merged.requires_confirmation is True
+
+
+def test_remote_command_spec_map_marks_note_writes_non_idempotent() -> None:
+    from ableton_cli.command_specs import remote_command_spec_map
+
+    specs = remote_command_spec_map()
+
+    assert specs["add_notes_to_clip"].side_effect.idempotent is False
+    assert specs["tracks_list"].side_effect.idempotent is True

--- a/tests/test_tcp_jsonl_transport.py
+++ b/tests/test_tcp_jsonl_transport.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 
 import pytest
 
-from ableton_cli.client.transport import TcpJsonlTransport
+from ableton_cli.client.transport import TcpJsonlTransport, socket_timeout_ms
 
 
 class _FakeJsonlServer:
@@ -95,6 +95,31 @@ def test_send_reuses_a_single_connection_across_calls(fake_server: _FakeJsonlSer
     assert first["result"] == {"echo": "ping"}
     assert second["result"] == {"echo": "ping"}
     assert fake_server.accept_count == 1
+
+
+def test_socket_read_deadline_outlives_the_request_deadline() -> None:
+    transport = TcpJsonlTransport(host="127.0.0.1", port=1, timeout_ms=5000)
+
+    assert transport.request_timeout_s == 5.0
+    assert transport.socket_timeout_s > transport.request_timeout_s
+
+
+def test_socket_timeout_is_derived_in_one_place() -> None:
+    transport = TcpJsonlTransport(host="127.0.0.1", port=1, timeout_ms=5000)
+
+    assert transport.socket_timeout_s == socket_timeout_ms(5000) / 1000
+
+
+def test_established_socket_uses_the_grace_extended_deadline(
+    fake_server: _FakeJsonlServer,
+) -> None:
+    transport = TcpJsonlTransport(host="127.0.0.1", port=fake_server.port, timeout_ms=2000)
+    try:
+        transport.send(_request("request-1"))
+        assert transport._sock is not None
+        assert transport._sock.gettimeout() == transport.socket_timeout_s
+    finally:
+        transport.close()
 
 
 def test_close_then_send_opens_a_new_connection(fake_server: _FakeJsonlServer) -> None:


### PR DESCRIPTION
タイムアウトした書き込みが再送で 2 回適用されうるバグ（3 つの独立した欠陥の合成）を塞ぐ。

## 変更

### 1. `may_have_executed` がクライアントに届くようにする
クライアントのソケット読み取り期限が `meta.request_timeout_ms` と同値だったため、Remote Script が構造化 TIMEOUT レスポンスを書き出すのと同時刻にクライアント側が先に落ちていた。丁寧に実装された `may_have_executed` シグナルが実運用でほぼ捨てられていた。

`_SOCKET_GRACE_MS = 2000` を導入し、`socket_timeout_ms()` を唯一の導出点にした。接続確立はメインスレッド待機を含まないため猶予なしの論理期限のまま。`backends.py` の 3 つの構築箇所は導出が transport 内部に閉じているため変更不要。

### 2. 非冪等コマンドの TIMEOUT 再試行を拒否
- `retry.on` の既定値から `TIMEOUT` を除去（既定は `REMOTE_BUSY` のみ）。`REMOTE_BUSY` は `self._queue.put()` より前のキュー深度チェックで送出されるため副作用ゼロが保証される（根拠をコードコメントに記載）。
- `retry.on` に `TIMEOUT` を含める場合、対象コマンドが `idempotent=True` でない限り `INVALID_ARGUMENT` で拒否。
- `may_have_executed=True` を伴う TIMEOUT は `retry.on` に関わらず再試行しない。

### 3. `remote_command_spec_map()`
batch のステップ名は remote コマンド名だが `command_spec_map()` は CLI コマンド名でキーされている。remote 名で引ける参照を追加した。`clip notes import-browser` と `browser load` のような多対一の写像は安全側にマージする（最強の副作用種別・`idempotent` は AND・`requires_confirmation` は OR）。実測で `load_instrument_or_effect` は `destructive` に解決される。

## 公開契約への影響
**意図的変更あり**（`retry.on` 既定値、非冪等 + TIMEOUT の拒否、ステップ失敗詳細の `may_have_executed`）。

ただし **`tests/snapshots/public_contract_snapshot.json` に差分は出ない**。`batch run` の args/result は `{"type": "object"}` であり `error.details` はコマンド別に列挙されていないため。仮定せず再生成して差分ゼロを確認済み。

`errors.remote_error_to_app_error` は既に `details` を運んでいたため変更不要。

## 既定値変更の影響を受ける既存 steps ファイル例
**なし。** `docs/` 配下の `.json` / `.md` に `retry` を使う例は存在しない。既存利用は `test_cli_new_commands.py` の 2 テストのみで、どちらも `tracks_list`（冪等）のため無変更で通る。

README / SKILL.md には batch の retry 挙動が未記載だったため追記した。

## 検証
`dev_checks` / `ruff check` / `ruff format --check` / `pytest`（1026 passed）/ `check_remote_script_runtime.py` / `generate_skill_docs.py` + `git diff --exit-code` / `update_public_contract_snapshot.py`（差分なし）。

品質ハーネスは `--baseline` 付きでも **pristine main の時点で既に exit 1**（baseline が古く 395 vs main 416、`register_commands` の既存 fail 1 件）。本 PR は fail-level violation 集合を main と完全一致に保ち、警告も増やしていない。

## Ableton Live 手動検証（必要）
破棄可能な Live Set で:

```bash
uv run ableton-cli --timeout-ms 15000 --output json wait-ready
uv run ableton-cli --timeout-ms 100 --output json clip notes add 0 0 --notes-json '[{"pitch":60,"start_time":0.0,"duration":0.5,"velocity":100,"mute":false}]'
uv run ableton-cli --output json clip notes get 0 0
```

TIMEOUT レスポンスに `error.details.may_have_executed` が含まれること（この PR 以前は届いていなかった）、およびノート数が二重に増えていないことを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)