### PR TITLE
1 tick がメインスレッドを占有する時間に上限を設ける

### DIFF
--- a/remote_script/AbletonCliRemote/control_surface.py
+++ b/remote_script/AbletonCliRemote/control_surface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hmac
 import queue
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -30,6 +31,18 @@ except Exception:  # pragma: no cover - only used outside Ableton for local chec
 
         def schedule_message(self, _delay: int, callback: Callable[[], None]) -> None:
             callback()
+
+
+#: Time a single drain tick may spend on Live's main thread before yielding.
+#:
+#: ``_drain_requests`` runs from ``schedule_message`` on the same thread that
+#: renders Live's UI and services audio, and ``MAX_PENDING_COMMANDS`` lets 512
+#: requests queue up — an unbounded drain would run all 512 Live API operations
+#: inside one tick and freeze the UI or drop audio. 5 ms is about a third of a
+#: 60 Hz frame: long enough that an ordinary burst clears in one or two ticks,
+#: short enough to stay imperceptible. Requests past the budget are not
+#: dropped; the existing reschedule path picks them up on the next tick.
+DRAIN_BUDGET_S = 0.005
 
 
 @dataclass(slots=True)
@@ -211,7 +224,7 @@ class AbletonCliRemoteSurface(_ControlSurface):
 
     def _scheduled_drain(self) -> None:
         try:
-            self._drain_requests()
+            self._drain_requests(budget_s=DRAIN_BUDGET_S)
         finally:
             with self._drain_lock:
                 self._drain_scheduled = False
@@ -219,8 +232,19 @@ class AbletonCliRemoteSurface(_ControlSurface):
         if needs_reschedule:
             self._schedule_drain()
 
-    def _drain_requests(self) -> None:
+    def _drain_requests(self, budget_s: float | None = None) -> None:
+        """Execute queued requests; ``budget_s=None`` drains without a deadline.
+
+        The budget is only checked *between* requests. A dispatch that has
+        already started always runs to completion — abandoning it midway would
+        leave Live in a half-applied state — and at least one request is always
+        processed, so an unusually small budget cannot starve the queue.
+        """
+        deadline = None if budget_s is None else time.monotonic() + budget_s
+        dispatched = 0
         while True:
+            if deadline is not None and dispatched and time.monotonic() >= deadline:
+                return
             try:
                 request = self._queue.get_nowait()
             except queue.Empty:
@@ -232,6 +256,7 @@ class AbletonCliRemoteSurface(_ControlSurface):
                     continue
                 request.executing = True
 
+            dispatched += 1
             try:
                 request.result = dispatch_command(self._backend, request.name, request.args)
             except Exception as exc:  # noqa: BLE001
@@ -246,7 +271,8 @@ class AbletonCliRemoteSurface(_ControlSurface):
         self._command_server.stop()
         self._event_source.detach()
         self._event_broker.close()
-        self._drain_requests()
+        # Shutting down: no UI or audio left to protect, so drain everything.
+        self._drain_requests(budget_s=None)
         with self._drain_lock:
             self._drain_scheduled = False
         super().disconnect()

--- a/tests/test_remote_control_surface.py
+++ b/tests/test_remote_control_surface.py
@@ -258,3 +258,146 @@ def test_surface_keeps_timeout_when_drain_is_not_scheduled(monkeypatch: pytest.M
         surface.disconnect()
 
     assert exc_info.value.code == "TIMEOUT"
+
+
+class _FakeClock:
+    """Deterministic stand-in for the ``time`` module used by the drain loop."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def _install_drain_harness(
+    monkeypatch: pytest.MonkeyPatch,
+    surface: control_surface_module.AbletonCliRemoteSurface,
+    *,
+    seconds_per_command: float,
+) -> tuple[_FakeClock, list[str], list[Callable[[], None]]]:
+    clock = _FakeClock()
+    executed: list[str] = []
+
+    def _dispatch(_backend: Any, name: str, _args: dict[str, Any]) -> dict[str, Any]:
+        executed.append(name)
+        clock.now += seconds_per_command
+        return {"name": name}
+
+    monkeypatch.setattr(control_surface_module, "time", clock)
+    monkeypatch.setattr(control_surface_module, "dispatch_command", _dispatch)
+
+    scheduled: list[Callable[[], None]] = []
+    surface.schedule_message = lambda _delay, callback: scheduled.append(  # type: ignore[method-assign]
+        callback
+    )
+    return clock, executed, scheduled
+
+
+def _enqueue(
+    surface: control_surface_module.AbletonCliRemoteSurface, name: str
+) -> control_surface_module._CommandRequest:
+    request = control_surface_module._CommandRequest(
+        name=name,
+        args={},
+        timeout_ms=1000,
+        event=threading.Event(),
+    )
+    surface._queue.put(request)
+    return request
+
+
+def test_scheduled_drain_stops_at_the_main_thread_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    surface = _make_surface(monkeypatch)
+    monkeypatch.setattr(control_surface_module, "DRAIN_BUDGET_S", 0.005)
+    _clock, executed, scheduled = _install_drain_harness(
+        monkeypatch, surface, seconds_per_command=0.004
+    )
+    for index in range(5):
+        _enqueue(surface, f"command-{index}")
+
+    surface._scheduled_drain()
+
+    assert executed == ["command-0", "command-1"]
+    assert not surface._queue.empty()
+
+
+def test_budget_overflow_is_rescheduled_until_every_request_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    surface = _make_surface(monkeypatch)
+    monkeypatch.setattr(control_surface_module, "DRAIN_BUDGET_S", 0.005)
+    clock, executed, scheduled = _install_drain_harness(
+        monkeypatch, surface, seconds_per_command=0.004
+    )
+    requests = [_enqueue(surface, f"command-{index}") for index in range(5)]
+
+    surface._scheduled_drain()
+    while scheduled:
+        callback = scheduled.pop(0)
+        clock.now = 0.0
+        callback()
+
+    assert executed == [f"command-{index}" for index in range(5)]
+    assert all(request.event.is_set() for request in requests)
+    assert surface._queue.empty()
+
+
+def test_budget_overflow_resets_the_drain_scheduled_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    surface = _make_surface(monkeypatch)
+    monkeypatch.setattr(control_surface_module, "DRAIN_BUDGET_S", 0.005)
+    clock, _executed, scheduled = _install_drain_harness(
+        monkeypatch, surface, seconds_per_command=0.004
+    )
+    for index in range(5):
+        _enqueue(surface, f"command-{index}")
+
+    surface._scheduled_drain()
+
+    # The flag was released and immediately re-taken by the pending reschedule.
+    assert len(scheduled) == 1
+    assert surface._drain_scheduled is True
+
+    while scheduled:
+        callback = scheduled.pop(0)
+        clock.now = 0.0
+        callback()
+
+    assert surface._drain_scheduled is False
+
+
+def test_exhausted_budget_still_dispatches_one_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    surface = _make_surface(monkeypatch)
+    monkeypatch.setattr(control_surface_module, "DRAIN_BUDGET_S", 0.0)
+    _clock, executed, _scheduled = _install_drain_harness(
+        monkeypatch, surface, seconds_per_command=0.004
+    )
+    for index in range(3):
+        _enqueue(surface, f"command-{index}")
+
+    surface._scheduled_drain()
+
+    assert executed == ["command-0"]
+
+
+def test_disconnect_drains_the_queue_regardless_of_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    surface = _make_surface(monkeypatch)
+    monkeypatch.setattr(control_surface_module, "DRAIN_BUDGET_S", 0.0)
+    _clock, executed, _scheduled = _install_drain_harness(
+        monkeypatch, surface, seconds_per_command=0.004
+    )
+    for index in range(5):
+        _enqueue(surface, f"command-{index}")
+
+    surface.disconnect()
+
+    assert executed == [f"command-{index}" for index in range(5)]
+    assert surface._queue.empty()


### PR DESCRIPTION
`_drain_requests()` はキューが空になるまで無制限にループしていた。これは `schedule_message(0, ...)` から Live の UI 描画とオーディオを処理するのと同じスレッド上で走る。`MAX_PENDING_COMMANDS = 512` まで積めるため、`batch stream` の大量投入で **最悪 512 件の Live API 操作が 1 tick 内に同期実行され**、UI フリーズとオーディオドロップアウトを招きうる。

## 変更

`DRAIN_BUDGET_S = 0.005` を導入。`_drain_requests(budget_s: float | None = None)` とし、`_scheduled_drain()` は予算付き、`disconnect()` は `budget_s=None` で完全排出する。

- **予算チェックは 1 件処理する前にのみ行う。** dispatch の途中で抜けると Live が中間状態になるため、開始した処理は必ず完了させる。
- 予算が極小でも **少なくとも 1 件は処理する**（飢餓なし）。
- 超過分は破棄せず、`_scheduled_drain()` の既存の再スケジュール経路に乗る。新しいロックやフラグは増やしていない。
- 計測は `time.monotonic()`（システム時刻変更の影響を受けないため）。

## `DRAIN_BUDGET_S = 0.005` の根拠
60 Hz フレームのおよそ 1/3。通常のバーストなら 1〜2 tick で捌け切る程度には長く、体感できない程度には短い。上限とその理由はコード上のコメントに残した。

## テスト
`time.monotonic` に依存するタイミング依存テストを避けるため、`control_surface_module.time` にフェイククロックを注入し、フェイク dispatch がクロックを進める決定論的な構成にした。

- 予算超過で 1 回の `_scheduled_drain()` が全件を処理しないこと
- 残りが次の tick で処理され最終的に全件完了すること
- 予算 0 でも 1 件は処理されること
- `_drain_scheduled` が解放され、保留中の再スケジュールに再取得されること
- `disconnect()` が予算に関係なく全件排出すること

## 公開契約への影響
**なし。** 内部スケジューリング挙動のみ。

## 検証
`dev_checks` / `ruff check` / `ruff format --check` / `pytest`（1017 passed）/ `check_remote_script_runtime.py` / `generate_skill_docs.py` + `git diff --exit-code` / `update_public_contract_snapshot.py`（差分なし）。

品質ハーネスは pristine main の時点で既に exit 1（baseline 陳腐化 + 既存 fail 1 件）。本 PR は fail-level violation 集合を main と一致に保ち、警告も増やしていない。

## Ableton Live 手動検証（必要）
`batch stream` に多数のステップを投入し、Live の UI が応答を保つことを確認する。可能なら `tools/latency_probe.py` を使う。CI では検証できない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)